### PR TITLE
Refactor docker build

### DIFF
--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -1,15 +1,10 @@
 FROM amazoncorretto:17-alpine3.17
 
-EXPOSE 8080
+# NOTE! gradle build must be done before docker build
 
 WORKDIR /ludos
+COPY docker-build/run.sh run.sh
+COPY server/build/libs/ludos-0.0.1-SNAPSHOT.jar ludos.jar
 
-COPY . .
-COPY docker-build/run.sh .
-
-RUN cd server && ./gradlew build -x test
-
-RUN apk add nodejs yarn
-RUN cd web && yarn install && yarn build && cd ..
-
+EXPOSE 8080
 ENTRYPOINT [ "./run.sh" ]

--- a/docker-build/run.sh
+++ b/docker-build/run.sh
@@ -2,5 +2,10 @@
 
 set -euo pipefail
 
-cd server
-./gradlew bootRun --args="--spring.profiles.active=$ENV_NAME"
+if [ -r "ludos.jar" ]; then
+    JAR_PATH=ludos.jar
+else
+    JAR_PATH="$(dirname "$0")/../server/build/libs/ludos-0.0.1-SNAPSHOT.jar"
+fi
+
+java -jar -Dspring.profiles.active="$ENV_NAME" "$JAR_PATH"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:web": "yarn workspace web lint",
     "lint:playwright": "yarn workspace playwright lint",
     "postinstall": "git config core.hooksPath .githooks",
-    "build:docker": "docker build -f docker-build/Dockerfile -t ludos:manual-$(git rev-parse --short HEAD) -t ludos:latest .",
+    "build:docker": "cd server && ./gradlew build -x test && docker build -f ../docker-build/Dockerfile -t ludos:manual-$(git rev-parse --short HEAD) -t ludos:latest ..",
     "run:docker": "docker run -it --net=host --env ENV_NAME=local ludos:latest",
     "ecr:login": "aws --profile oph-ludos-utility ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin 505953557276.dkr.ecr.eu-west-1.amazonaws.com",
     "ecr:publish": "docker tag ludos:manual-$(git rev-parse --short HEAD) 505953557276.dkr.ecr.eu-west-1.amazonaws.com/ludos:manual-$(git rev-parse --short HEAD) && docker push 505953557276.dkr.ecr.eu-west-1.amazonaws.com/ludos:manual-$(git rev-parse --short HEAD)"


### PR DESCRIPTION
- run server with java instead of gradle in docker to get rid of gradle dependency in docker image
- do gradle build outside of docker build for a faster gh actions build
- fix sometimes missing static dir after gradle build

Local docker build now takes 11 s instead of 90 s and docker image is under 400 MiB when it used to be over 2 GiB.