### PR TITLE
Handle login errors more gracefully

### DIFF
--- a/server/src/main/kotlin/fi/oph/ludos/auth/CasConfig.kt
+++ b/server/src/main/kotlin/fi/oph/ludos/auth/CasConfig.kt
@@ -19,6 +19,7 @@ import org.springframework.security.core.Authentication
 import org.springframework.security.core.AuthenticationException
 import org.springframework.security.core.userdetails.*
 import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.security.web.authentication.AuthenticationFailureHandler
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler
 import javax.servlet.http.HttpServletRequest
@@ -102,13 +103,17 @@ class LudosAuthenticationSuccessHandler : SavedRequestAwareAuthenticationSuccess
     }
 }
 
-class LudosAuthenticationFailureHandler : SimpleUrlAuthenticationFailureHandler() {
+class LudosAuthenticationFailureHandler : AuthenticationFailureHandler {
     private val ludosLogger: Logger = LoggerFactory.getLogger(javaClass)
 
     override fun onAuthenticationFailure(
-        request: HttpServletRequest?, response: HttpServletResponse?, exception: AuthenticationException?
+        request: HttpServletRequest, response: HttpServletResponse, exception: AuthenticationException
     ) {
         ludosLogger.warn("Login failed: ${exception?.message}")
-        super.onAuthenticationFailure(request, response, exception)
+        response.status = HttpServletResponse.SC_UNAUTHORIZED
+        response.contentType = "text/html"
+        response.writer.write("""<h1>Odottamaton virhe kirjautuessa sisään. Yritä uudestaan <a href="/">tästä.</a></h1>""")
+        response.writer.write("""<h1>Oväntat fel vid inloggning. Försök igen <a href="/">här.</a></h1>""")
+        response.writer.flush()
     }
 }

--- a/server/src/main/kotlin/fi/oph/ludos/auth/CasUserDetailsService.kt
+++ b/server/src/main/kotlin/fi/oph/ludos/auth/CasUserDetailsService.kt
@@ -1,5 +1,7 @@
 package fi.oph.ludos.auth
 
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.security.cas.authentication.CasAssertionAuthenticationToken
 import org.springframework.security.core.userdetails.AuthenticationUserDetailsService
@@ -11,11 +13,24 @@ class CasUserDetailsService(
     @Autowired val kayttooikeusClient: KayttooikeusClient,
     @Autowired val oppijanumerorekisteriClient: OppijanumerorekisteriClient
 ) : AuthenticationUserDetailsService<CasAssertionAuthenticationToken> {
+    private val logger: Logger = LoggerFactory.getLogger(javaClass)
+
     override fun loadUserDetails(token: CasAssertionAuthenticationToken): Kayttajatiedot {
         val username = token.name
         val users = kayttooikeusClient.kayttooikeudet(username)
-        val user =
-            users.find { it.username == username } ?: throw UsernameNotFoundException("User '$username' not found")
+        val user = users.find { it.username == username }
+        if (user == null) {
+            logger.warn("Username '${username}' not found in kayttooikeus service")
+            return Kayttajatiedot(
+                oidHenkilo = "",
+                username = username,
+                kayttajaTyyppi = "",
+                organisaatiot = emptyList(),
+                etunimet = "",
+                sukunimi = "",
+                asiointiKieli = null
+            )
+        }
 
         val oppijanumerorekisteriHenkilo = oppijanumerorekisteriClient.getUserDetailsByOid(user.oidHenkilo)
 

--- a/server/src/main/kotlin/fi/oph/ludos/exception/ApiExceptionHandler.kt
+++ b/server/src/main/kotlin/fi/oph/ludos/exception/ApiExceptionHandler.kt
@@ -40,7 +40,6 @@ class ApiExceptionHandler {
 
     @ExceptionHandler(AccessDeniedException::class)
     fun handleAccessdenied(ex: AccessDeniedException): ResponseEntity<String> {
-        logger.error("Access denied for user: ${ex.message}")
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ex.message)
     }
 }


### PR DESCRIPTION
If user not found in käyttöoikeus service, log user in with UNAUTHORIZED role and show message about missing privileges.

If another unexpected error occurs, show a more useful error message with a retry link.