### PR TITLE
Hide taitotaso from suko assignment card and content page

### DIFF
--- a/playwright/all_tests/assignment/assignment.spec.ts
+++ b/playwright/all_tests/assignment/assignment.spec.ts
@@ -81,7 +81,7 @@ test.describe('Suko assignment form tests', () => {
     await expect(updatedAssignmentHeader).toHaveText('Testi tehtävä muokattu')
 
     await expect(page.getByText('Tehtävätyyppi: Tekstin tiivistäminen')).toBeVisible()
-    await expect(page.getByText('Tavoitetaso:A1.2 Kehittyvä alkeiskielitaito')).toBeVisible()
+    // await expect(page.getByText('Tavoitetaso:A1.2 Kehittyvä alkeiskielitaito')).toBeVisible()
     await expect(
       page.getByText('Laaja-alainen osaaminen:Globaali- ja kulttuuriosaaminen, Hyvinvointiosaaminen, V')
     ).toBeVisible()

--- a/web/src/components/contentpage/AssignmentContent.tsx
+++ b/web/src/components/contentpage/AssignmentContent.tsx
@@ -1,7 +1,7 @@
 import { AssignmentIn, Exam } from '../../types'
 import { useTranslation } from 'react-i18next'
 import { useKoodisto } from '../../hooks/useKoodisto'
-import { ContentContent, ContentActionRow, ContentInstruction } from './ContentCommon'
+import { ContentActionRow, ContentContent, ContentInstruction } from './ContentCommon'
 import { isLdAssignment, isPuhviAssignment, isSukoAssignment } from '../exam/assignment/assignmentUtils'
 
 type AssignmentContentProps = {
@@ -27,10 +27,10 @@ export const AssignmentContent = ({ assignment, exam, language }: AssignmentCont
                 <span className="pr-1 font-semibold">{t('assignment.tehtavatyyppi')}:</span>{' '}
                 {getKoodiLabel(assignment.assignmentTypeKoodiArvo, 'tehtavatyyppisuko')}
               </li>
-              <li>
-                <span className="pr-1 font-semibold">{t('assignment.tavoitetaso')}:</span>
-                {getKoodiLabel(assignment.tavoitetasoKoodiArvo, 'taitotaso')}
-              </li>
+              {/*<li>*/}
+              {/*  <span className="pr-1 font-semibold">{t('assignment.tavoitetaso')}:</span>*/}
+              {/*  {getKoodiLabel(assignment.tavoitetasoKoodiArvo, 'taitotaso')}*/}
+              {/*</li>*/}
               <li>
                 <span className="pr-1 font-semibold">{t('assignment.aihe')}:</span>
                 {assignment.aiheKoodiArvos.length > 0 ? getKoodisLabel(assignment.aiheKoodiArvos, 'aihesuko') : '-'}

--- a/web/src/components/exam/assignment/AssignmentCard.tsx
+++ b/web/src/components/exam/assignment/AssignmentCard.tsx
@@ -100,10 +100,10 @@ export const AssignmentCard = ({ language, assignment, exam }: AssignmentCardPro
                 <p className="text-xs text-gray-secondary">{t('assignment.aihe')}</p>
                 <p className="text-xs text-black">{getKoodisLabel(assignment.aiheKoodiArvos, 'aihesuko')}</p>
               </div>
-              <div>
-                <p className="text-xs text-gray-secondary">{t('assignment.tavoitetaso')}</p>
-                <p className="text-xs text-black">{getKoodiLabel(assignment.tavoitetasoKoodiArvo, 'taitotaso')}</p>
-              </div>
+              {/*<div>*/}
+              {/*  <p className="text-xs text-gray-secondary">{t('assignment.tavoitetaso')}</p>*/}
+              {/*  <p className="text-xs text-black">{getKoodiLabel(assignment.tavoitetasoKoodiArvo, 'taitotaso')}</p>*/}
+              {/*</div>*/}
             </>
           )}
           <div>


### PR DESCRIPTION
We're still not sure how to play with taitotaso, so hide it from now, except from the form.