### PR TITLE
Run playwright against vite locally

### DIFF
--- a/playwright/all_tests/cas_auth/login.spec.ts
+++ b/playwright/all_tests/cas_auth/login.spec.ts
@@ -5,7 +5,7 @@ const casLoginUrl =
   'https://virkailija.untuvaopintopolku.fi/cas/login?service=http%3A%2F%2Flocalhost%3A8080%2Fj_spring_cas_security_check'
 
 test('yllapitaja can login and logout', async ({ page }) => {
-  await page.goto('/')
+  await page.goto('/vitelogin')
   await page.waitForURL(casLoginUrl)
   await page.locator('#username').fill(process.env.TESTIKAYTTAJA_YLLAPITAJA_USERNAME!)
   await page.locator('#password').fill(process.env.TESTIKAYTTAJA_YLLAPITAJA_PASSWORD!)
@@ -14,6 +14,5 @@ test('yllapitaja can login and logout', async ({ page }) => {
 
   await page.getByTestId('header-user-dropdown-expand').click()
   await page.getByTestId('logout-button').click()
-  await page.goto('/')
   await page.waitForURL(casLoginUrl)
 })

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test'
+import * as process from 'process'
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -28,7 +29,7 @@ export default defineConfig({
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
     // baseURL: process.env.CI ? 'http://localhost:8080' : 'http://localhost:8000',
-    baseURL: 'http://localhost:8080',
+    baseURL: process.env.CI ? 'http://localhost:8080' : 'http://localhost:8000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/web/src/components/routes/LudosRoutes.tsx
+++ b/web/src/components/routes/LudosRoutes.tsx
@@ -201,6 +201,7 @@ function AuthorizedRoutes() {
         }
       />
       <Route path={`/${luvatonKey}`} element={<UnauthorizedPage />} />
+      <Route path={`/vitelogin`} element={<Navigate replace to="/" />} />
       <Route
         path="*"
         element={

--- a/web/src/hooks/useFetch.tsx
+++ b/web/src/hooks/useFetch.tsx
@@ -14,7 +14,7 @@ export function useFetch<T>(url: string, isNew: boolean = false) {
       try {
         setLoading(true)
 
-        const response = await fetch(`/api/${url}`, { method: 'GET' })
+        const response = await fetch(`/api/${url}`, { method: 'GET', redirect: 'error' })
 
         if (!response.ok) {
           setError(true)

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -4,7 +4,7 @@ import LanguageDetector from 'i18next-browser-languagedetector'
 
 const loadResources = async () => {
   try {
-    const result = await fetch('/api/localization')
+    const result = await fetch('/api/localization', { redirect: 'error' })
 
     if (!result.ok) {
       return []

--- a/web/src/request.ts
+++ b/web/src/request.ts
@@ -14,7 +14,8 @@ const doRequest = async (
   await fetch(url, {
     method,
     body,
-    headers
+    headers,
+    redirect: 'error'
   })
 
 export async function createAssignment<T>(body: T): Promise<{ id: string }> {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   server: {
     port: 8000,
     proxy: {
+      '/vitelogin': 'http://localhost:8080/',
       '/api': 'http://localhost:8080/'
     }
   },


### PR DESCRIPTION
And also fix fetches dangerously following redirects. This fix is also needed to prevent CAS from redirecting us to for example /api/localizations with vite.