### PR TITLE
Replace OPH Artifactory with Github Packages

### DIFF
--- a/.github/workflows/build_test_push.yml
+++ b/.github/workflows/build_test_push.yml
@@ -52,6 +52,8 @@ jobs:
           aws-region: eu-west-1
       - name: Gradle build, including API tests
         uses: gradle/gradle-build-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           arguments: build
           build-root-directory: server

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -15,14 +15,10 @@ java.sourceCompatibility = JavaVersion.VERSION_17
 
 repositories {
     mavenCentral()
-    maven(url = "https://artifactory.opintopolku.fi/artifactory/oph-sade-snapshot-local") {
-        mavenContent {
-            snapshotsOnly()
-        }
-    }
-    maven(url = "https://artifactory.opintopolku.fi/artifactory/oph-sade-release-local") {
-        mavenContent {
-            releasesOnly()
+    maven(url = "https://maven.pkg.github.com/Opetushallitus/java-utils") {
+        credentials {
+            username = "does-not-matter"
+            password = project.findProperty("gpr.key") as String? ?: System.getenv("GITHUB_TOKEN")
         }
     }
 }


### PR DESCRIPTION
OPH is moving to Github Packages so let's get our maven packages from there.