### PR TITLE
Tehtävä lomakkeen nappi rivi olemaan oma komponentti ja paranna propsien nimiä

### DIFF
--- a/web/src/components/forms/AssignmentFormButtonRow.tsx
+++ b/web/src/components/forms/AssignmentFormButtonRow.tsx
@@ -14,8 +14,8 @@ type AssignmentFormButtonRowProps<T extends AnyAssignmentFormType> = {
   isUpdate: boolean
   methods: UseFormReturn<T>
   deleteModalState: {
-    openDeleteModal: boolean
-    setOpenDeleteModal: (value: boolean) => void
+    isDeleteModalOpen: boolean
+    setIsDeleteModalOpen: (value: boolean) => void
   }
   publishState?: PublishState
 }
@@ -28,7 +28,7 @@ export const AssignmentFormButtonRow = <T extends AnyAssignmentFormType>({
     getValues,
     formState: { errors, isValid, isSubmitting }
   },
-  deleteModalState: { openDeleteModal, setOpenDeleteModal },
+  deleteModalState: { isDeleteModalOpen, setIsDeleteModalOpen },
   publishState
 }: AssignmentFormButtonRowProps<T>) => {
   const { lt } = useLudosTranslation()
@@ -41,7 +41,7 @@ export const AssignmentFormButtonRow = <T extends AnyAssignmentFormType>({
         actions={{
           onSubmitClick: () => submitAssignment(PublishState.Published),
           onSaveDraftClick: () => submitAssignment(PublishState.Draft),
-          onDeleteClick: () => setOpenDeleteModal(true),
+          onDeleteClick: () => setIsDeleteModalOpen(true),
           onCancelClick: () => navigate(-1)
         }}
         state={{
@@ -54,9 +54,9 @@ export const AssignmentFormButtonRow = <T extends AnyAssignmentFormType>({
       />
       <DeleteModal
         modalTitle={lt.contentDeleteModalTitle[ContentType.koetehtavat]}
-        open={openDeleteModal}
+        open={isDeleteModalOpen}
         onDeleteAction={() => submitAssignment(PublishState.Deleted)}
-        onClose={() => setOpenDeleteModal(false)}>
+        onClose={() => setIsDeleteModalOpen(false)}>
         <div className="h-[15vh] p-6">
           <p>
             {lt.contentDeleteModalText[ContentType.koetehtavat](

--- a/web/src/components/forms/AssignmentFormButtonRow.tsx
+++ b/web/src/components/forms/AssignmentFormButtonRow.tsx
@@ -1,0 +1,70 @@
+import { ContentType, PublishState } from '../../types'
+import { FormButtonRow } from './formCommon/FormButtonRow'
+import { DeleteModal } from '../modal/DeleteModal'
+import { useNavigate } from 'react-router-dom'
+import { useContext } from 'react'
+import { LudosContext } from '../../contexts/LudosContext'
+import { useLudosTranslation } from '../../hooks/useLudosTranslation'
+import { UseFormReturn } from 'react-hook-form'
+import { AnyAssignmentFormType } from './schemas/assignmentSchema'
+
+type AssignmentFormButtonRowProps<T extends AnyAssignmentFormType> = {
+  submitAssignment: (publishState: PublishState) => void
+  submitError: string
+  isUpdate: boolean
+  methods: UseFormReturn<T>
+  deleteModalState: {
+    openDeleteModal: boolean
+    setOpenDeleteModal: (value: boolean) => void
+  }
+  publishState?: PublishState
+}
+
+export const AssignmentFormButtonRow = <T extends AnyAssignmentFormType>({
+  submitAssignment,
+  submitError,
+  isUpdate,
+  methods: {
+    getValues,
+    formState: { errors, isValid, isSubmitting }
+  },
+  deleteModalState: { openDeleteModal, setOpenDeleteModal },
+  publishState
+}: AssignmentFormButtonRowProps<T>) => {
+  const { lt } = useLudosTranslation()
+  const navigate = useNavigate()
+  const { uiLanguage } = useContext(LudosContext)
+
+  return (
+    <>
+      <FormButtonRow
+        actions={{
+          onSubmitClick: () => submitAssignment(PublishState.Published),
+          onSaveDraftClick: () => submitAssignment(PublishState.Draft),
+          onDeleteClick: () => setOpenDeleteModal(true),
+          onCancelClick: () => navigate(-1)
+        }}
+        state={{
+          isUpdate,
+          disableSubmit: isSubmitting || !isValid,
+          publishState
+        }}
+        formHasValidationErrors={Object.keys(errors).length > 0}
+        errorMessage={submitError}
+      />
+      <DeleteModal
+        modalTitle={lt.contentDeleteModalTitle[ContentType.koetehtavat]}
+        open={openDeleteModal}
+        onDeleteAction={() => submitAssignment(PublishState.Deleted)}
+        onClose={() => setOpenDeleteModal(false)}>
+        <div className="h-[15vh] p-6">
+          <p>
+            {lt.contentDeleteModalText[ContentType.koetehtavat](
+              uiLanguage === 'fi' ? getValues().nameFi : getValues().nameSv
+            )}
+          </p>
+        </div>
+      </DeleteModal>
+    </>
+  )
+}

--- a/web/src/components/forms/CertificateForm.tsx
+++ b/web/src/components/forms/CertificateForm.tsx
@@ -239,7 +239,7 @@ const CertificateForm = ({ action }: CertificateFormProps) => {
         description={action === ContentFormAction.uusi ? t('form.kuvaustodistus') : t('form.muokkauskuvaus')}
       />
       <FormProvider {...methods}>
-        <form className="border-y-2 border-gray-light py-5" id="newAssignment" onSubmit={(e) => e.preventDefault()}>
+        <form className="border-y-2 border-gray-light py-5" onSubmit={(e) => e.preventDefault()}>
           {exam === Exam.LD && <FormAineDropdown />}
 
           <div className="mb-2 text-lg font-semibold">{t('form.sisalto')}</div>
@@ -326,7 +326,7 @@ const CertificateForm = ({ action }: CertificateFormProps) => {
         }}
         state={{
           isUpdate,
-          isSubmitting,
+          disableSubmit: isSubmitting,
           publishState: watchPublishState
         }}
         formHasValidationErrors={Object.keys(errors).length > 0}

--- a/web/src/components/forms/CertificateForm.tsx
+++ b/web/src/components/forms/CertificateForm.tsx
@@ -46,7 +46,7 @@ const CertificateForm = ({ action }: CertificateFormProps) => {
   const [submitError, setSubmitError] = useState<string>('')
   const [newAttachmentFi, setNewAttachmentFi] = useState<File | null>(null)
   const [newAttachmentSv, setNewAttachmentSv] = useState<File | null>(null)
-  const [openDeleteModal, setOpenDeleteModal] = useState(false)
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
 
   const exam = match!.params.exam!.toUpperCase() as Exam
   const id = match!.params.id
@@ -321,7 +321,7 @@ const CertificateForm = ({ action }: CertificateFormProps) => {
         actions={{
           onSubmitClick: () => submitCertificate(PublishState.Published),
           onSaveDraftClick: () => submitCertificate(PublishState.Draft),
-          onDeleteClick: () => setOpenDeleteModal(true),
+          onDeleteClick: () => setIsDeleteModalOpen(true),
           onCancelClick: handleCancelClick
         }}
         state={{
@@ -335,9 +335,9 @@ const CertificateForm = ({ action }: CertificateFormProps) => {
 
       <DeleteModal
         modalTitle={lt.contentDeleteModalTitle[ContentType.todistukset]}
-        open={openDeleteModal}
+        open={isDeleteModalOpen}
         onDeleteAction={() => submitCertificate(PublishState.Deleted)}
-        onClose={() => setOpenDeleteModal(false)}>
+        onClose={() => setIsDeleteModalOpen(false)}>
         <div className="h-[15vh] p-6">
           <p>{lt.contentDeleteModalText[ContentType.todistukset](watchNameFi)}</p>
         </div>

--- a/web/src/components/forms/InstructionForm.tsx
+++ b/web/src/components/forms/InstructionForm.tsx
@@ -72,7 +72,7 @@ const InstructionForm = ({ action }: InstructionFormProps) => {
   const [attachmentDataFi, setAttachmentDataFi] = useState<AttachmentData[]>([])
   const [attachmentDataSv, setAttachmentDataSv] = useState<AttachmentData[]>([])
   const [fileUploadErrorMessage, setFileUploadErrorMessage] = useState<string | null>(null)
-  const [openDeleteModal, setOpenDeleteModal] = useState(false)
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
   const [isLoaded, setIsLoaded] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string>('')
@@ -425,7 +425,7 @@ const InstructionForm = ({ action }: InstructionFormProps) => {
         actions={{
           onSubmitClick: () => submitInstruction(PublishState.Published),
           onSaveDraftClick: () => submitInstruction(PublishState.Draft),
-          onDeleteClick: () => setOpenDeleteModal(true),
+          onDeleteClick: () => setIsDeleteModalOpen(true),
           onCancelClick: handleCancelClick
         }}
         state={{
@@ -439,9 +439,9 @@ const InstructionForm = ({ action }: InstructionFormProps) => {
 
       <DeleteModal
         modalTitle={lt.contentDeleteModalTitle[ContentType.ohjeet]}
-        open={openDeleteModal}
+        open={isDeleteModalOpen}
         onDeleteAction={() => submitInstruction(PublishState.Deleted)}
-        onClose={() => setOpenDeleteModal(false)}>
+        onClose={() => setIsDeleteModalOpen(false)}>
         <div className="h-[15vh] p-6">
           <p>{lt.contentDeleteModalText[ContentType.ohjeet](uiLanguage === 'fi' ? watchNameFi : watchNameSv)}</p>
         </div>

--- a/web/src/components/forms/InstructionForm.tsx
+++ b/web/src/components/forms/InstructionForm.tsx
@@ -311,10 +311,7 @@ const InstructionForm = ({ action }: InstructionFormProps) => {
       />
       <BlockNavigation shouldBlock={isDirty && !isSubmitting} />
       <FormProvider {...methods}>
-        <form
-          className="min-h-[50vh] border-y-2 border-gray-light py-5"
-          id="newAssignment"
-          onSubmit={(e) => e.preventDefault()}>
+        <form className="min-h-[50vh] border-y-2 border-gray-light py-5" onSubmit={(e) => e.preventDefault()}>
           <input type="hidden" {...register('exam')} />
 
           {exam === Exam.LD && <FormAineDropdown />}
@@ -433,7 +430,7 @@ const InstructionForm = ({ action }: InstructionFormProps) => {
         }}
         state={{
           isUpdate,
-          isSubmitting,
+          disableSubmit: isSubmitting,
           publishState: watchPublishState
         }}
         formHasValidationErrors={Object.keys(errors).length > 0}

--- a/web/src/components/forms/LdAssignmentForm.tsx
+++ b/web/src/components/forms/LdAssignmentForm.tsx
@@ -12,6 +12,7 @@ import { currentKoodistoSelectOptions, koodistoSelectOptions } from '../ludosSel
 import { LudosSelect } from '../ludosSelect/LudosSelect'
 import { FormAineDropdown } from './formCommon/FormAineDropdown'
 import { BlockNavigation } from '../BlockNavigation'
+import { AssignmentFormButtonRow } from './AssignmentFormButtonRow'
 
 type LdAssignmentFormProps = {
   action: ContentFormAction
@@ -22,11 +23,11 @@ export const LdAssignmentForm = ({ action, id }: LdAssignmentFormProps) => {
   const { t } = useTranslation()
   const { koodistos } = useKoodisto()
 
-  const { methods, handleMultiselectOptionChange, AssignmentFormButtonRow, isSubmitting } =
-    useAssignmentForm<LdAssignmentFormType>(Exam.LD, id)
+  const { methods, handleMultiselectOptionChange, submitAssignment, submitError, openDeleteModal, setOpenDeleteModal } =
+    useAssignmentForm<LdAssignmentFormType>(Exam.LD, id, action)
   const {
     watch,
-    formState: { errors }
+    formState: { errors, isSubmitting }
   } = methods
 
   const currentNameFi = watch('nameFi')
@@ -42,7 +43,7 @@ export const LdAssignmentForm = ({ action, id }: LdAssignmentFormProps) => {
       />
       <BlockNavigation shouldBlock={methods.formState.isDirty && !isSubmitting} />
       <FormProvider {...methods}>
-        <form className="border-y-2 border-gray-light py-5" id="newAssignment" onSubmit={(e) => e.preventDefault()}>
+        <form className="border-y-2 border-gray-light py-5" onSubmit={(e) => e.preventDefault()}>
           <fieldset className="mb-6">
             <FieldLabel id="lukuvuosiKoodiArvos" name={t('form.lukuvuosi')} required />
             <LudosSelect
@@ -80,7 +81,17 @@ export const LdAssignmentForm = ({ action, id }: LdAssignmentFormProps) => {
         </form>
       </FormProvider>
 
-      <AssignmentFormButtonRow publishState={watchPublishState} />
+      <AssignmentFormButtonRow
+        methods={methods}
+        submitAssignment={submitAssignment}
+        isUpdate={action === ContentFormAction.muokkaus}
+        deleteModalState={{
+          openDeleteModal,
+          setOpenDeleteModal
+        }}
+        publishState={watchPublishState}
+        submitError={submitError}
+      />
     </>
   )
 }

--- a/web/src/components/forms/LdAssignmentForm.tsx
+++ b/web/src/components/forms/LdAssignmentForm.tsx
@@ -23,8 +23,14 @@ export const LdAssignmentForm = ({ action, id }: LdAssignmentFormProps) => {
   const { t } = useTranslation()
   const { koodistos } = useKoodisto()
 
-  const { methods, handleMultiselectOptionChange, submitAssignment, submitError, openDeleteModal, setOpenDeleteModal } =
-    useAssignmentForm<LdAssignmentFormType>(Exam.LD, id, action)
+  const {
+    methods,
+    handleMultiselectOptionChange,
+    submitAssignment,
+    submitError,
+    isDeleteModalOpen,
+    setIsDeleteModalOpen
+  } = useAssignmentForm<LdAssignmentFormType>(Exam.LD, id, action)
   const {
     watch,
     formState: { errors, isSubmitting }
@@ -86,8 +92,8 @@ export const LdAssignmentForm = ({ action, id }: LdAssignmentFormProps) => {
         submitAssignment={submitAssignment}
         isUpdate={action === ContentFormAction.muokkaus}
         deleteModalState={{
-          openDeleteModal,
-          setOpenDeleteModal
+          isDeleteModalOpen,
+          setIsDeleteModalOpen
         }}
         publishState={watchPublishState}
         submitError={submitError}

--- a/web/src/components/forms/PuhviAssignmentForm.tsx
+++ b/web/src/components/forms/PuhviAssignmentForm.tsx
@@ -23,8 +23,14 @@ export const PuhviAssignmentForm = ({ action, id }: PuhviAssignmentFormProps) =>
   const { t } = useTranslation()
   const { koodistos } = useKoodisto()
 
-  const { methods, handleMultiselectOptionChange, submitAssignment, submitError, openDeleteModal, setOpenDeleteModal } =
-    useAssignmentForm<PuhviAssignmentFormType>(Exam.PUHVI, id, action)
+  const {
+    methods,
+    handleMultiselectOptionChange,
+    submitAssignment,
+    submitError,
+    isDeleteModalOpen,
+    setIsDeleteModalOpen
+  } = useAssignmentForm<PuhviAssignmentFormType>(Exam.PUHVI, id, action)
 
   const {
     watch,
@@ -94,8 +100,8 @@ export const PuhviAssignmentForm = ({ action, id }: PuhviAssignmentFormProps) =>
         submitAssignment={submitAssignment}
         isUpdate={action === ContentFormAction.muokkaus}
         deleteModalState={{
-          openDeleteModal,
-          setOpenDeleteModal
+          isDeleteModalOpen,
+          setIsDeleteModalOpen
         }}
         publishState={watchPublishState}
         submitError={submitError}

--- a/web/src/components/forms/PuhviAssignmentForm.tsx
+++ b/web/src/components/forms/PuhviAssignmentForm.tsx
@@ -12,6 +12,7 @@ import { FormContentInput } from './formCommon/FormContentInput'
 import { LudosSelect } from '../ludosSelect/LudosSelect'
 import { currentKoodistoSelectOptions, koodistoSelectOptions } from '../ludosSelect/helpers'
 import { BlockNavigation } from '../BlockNavigation'
+import { AssignmentFormButtonRow } from './AssignmentFormButtonRow'
 
 type PuhviAssignmentFormProps = {
   action: ContentFormAction
@@ -22,13 +23,13 @@ export const PuhviAssignmentForm = ({ action, id }: PuhviAssignmentFormProps) =>
   const { t } = useTranslation()
   const { koodistos } = useKoodisto()
 
-  const { methods, handleMultiselectOptionChange, AssignmentFormButtonRow, isSubmitting } =
-    useAssignmentForm<PuhviAssignmentFormType>(Exam.PUHVI, id)
+  const { methods, handleMultiselectOptionChange, submitAssignment, submitError, openDeleteModal, setOpenDeleteModal } =
+    useAssignmentForm<PuhviAssignmentFormType>(Exam.PUHVI, id, action)
 
   const {
     watch,
     control,
-    formState: { errors }
+    formState: { errors, isSubmitting }
   } = methods
 
   const currentNameFi = watch('nameFi')
@@ -44,7 +45,7 @@ export const PuhviAssignmentForm = ({ action, id }: PuhviAssignmentFormProps) =>
       />
       <BlockNavigation shouldBlock={methods.formState.isDirty && !isSubmitting} />
       <FormProvider {...methods}>
-        <form className="border-y-2 border-gray-light py-5" id="newAssignment" onSubmit={(e) => e.preventDefault()}>
+        <form className="border-y-2 border-gray-light py-5" onSubmit={(e) => e.preventDefault()}>
           <fieldset className="mb-6">
             <FieldLabel id="lukuvuosiKoodiArvos" name={t('form.lukuvuosi')} required />
             <LudosSelect
@@ -88,7 +89,17 @@ export const PuhviAssignmentForm = ({ action, id }: PuhviAssignmentFormProps) =>
         </form>
       </FormProvider>
 
-      <AssignmentFormButtonRow publishState={watchPublishState} />
+      <AssignmentFormButtonRow
+        methods={methods}
+        submitAssignment={submitAssignment}
+        isUpdate={action === ContentFormAction.muokkaus}
+        deleteModalState={{
+          openDeleteModal,
+          setOpenDeleteModal
+        }}
+        publishState={watchPublishState}
+        submitError={submitError}
+      />
     </>
   )
 }

--- a/web/src/components/forms/SukoAssignmentForm.tsx
+++ b/web/src/components/forms/SukoAssignmentForm.tsx
@@ -30,8 +30,14 @@ export const SukoAssignmentForm = ({ action, id }: SukoAssignmentFormProps) => {
   const { t } = useTranslation()
   const { koodistos, getKoodiLabel, getOppimaaraLabel } = useKoodisto()
 
-  const { methods, handleMultiselectOptionChange, submitAssignment, submitError, openDeleteModal, setOpenDeleteModal } =
-    useAssignmentForm<SukoAssignmentFormType>(Exam.SUKO, id, action)
+  const {
+    methods,
+    handleMultiselectOptionChange,
+    submitAssignment,
+    submitError,
+    isDeleteModalOpen,
+    setIsDeleteModalOpen
+  } = useAssignmentForm<SukoAssignmentFormType>(Exam.SUKO, id, action)
 
   const {
     watch,
@@ -159,8 +165,8 @@ export const SukoAssignmentForm = ({ action, id }: SukoAssignmentFormProps) => {
         submitAssignment={submitAssignment}
         isUpdate={action === ContentFormAction.muokkaus}
         deleteModalState={{
-          openDeleteModal,
-          setOpenDeleteModal
+          isDeleteModalOpen,
+          setIsDeleteModalOpen
         }}
         publishState={watchPublishState}
         submitError={submitError}

--- a/web/src/components/forms/SukoAssignmentForm.tsx
+++ b/web/src/components/forms/SukoAssignmentForm.tsx
@@ -19,6 +19,7 @@ import {
 } from '../ludosSelect/helpers'
 import { useCallback } from 'react'
 import { BlockNavigation } from '../BlockNavigation'
+import { AssignmentFormButtonRow } from './AssignmentFormButtonRow'
 
 type SukoAssignmentFormProps = {
   action: ContentFormAction
@@ -29,16 +30,17 @@ export const SukoAssignmentForm = ({ action, id }: SukoAssignmentFormProps) => {
   const { t } = useTranslation()
   const { koodistos, getKoodiLabel, getOppimaaraLabel } = useKoodisto()
 
-  const { methods, handleMultiselectOptionChange, AssignmentFormButtonRow, isSubmitting } =
-    useAssignmentForm<SukoAssignmentFormType>(Exam.SUKO, id)
+  const { methods, handleMultiselectOptionChange, submitAssignment, submitError, openDeleteModal, setOpenDeleteModal } =
+    useAssignmentForm<SukoAssignmentFormType>(Exam.SUKO, id, action)
 
   const {
     watch,
     control,
     setValue,
     clearErrors,
-    formState: { errors }
+    formState: { errors, isSubmitting }
   } = methods
+
   const currentNameFi = watch('nameFi')
   const currentOppimaara: Oppimaara = watch('oppimaara')
   const currentTavoitetaso = watch('tavoitetasoKoodiArvo')
@@ -71,7 +73,7 @@ export const SukoAssignmentForm = ({ action, id }: SukoAssignmentFormProps) => {
       />
       <BlockNavigation shouldBlock={methods.formState.isDirty && !isSubmitting} />
       <FormProvider {...methods}>
-        <form className="border-y-2 border-gray-light py-5" id="newAssignment" onSubmit={(e) => e.preventDefault()}>
+        <form className="border-y-2 border-gray-light py-5" onSubmit={(e) => e.preventDefault()}>
           <fieldset className="mb-6">
             <FieldLabel id="oppimaara" name={t('form.oppimaara')} required />
             <LudosSelect
@@ -152,7 +154,17 @@ export const SukoAssignmentForm = ({ action, id }: SukoAssignmentFormProps) => {
         </form>
       </FormProvider>
 
-      <AssignmentFormButtonRow publishState={watchPublishState} />
+      <AssignmentFormButtonRow
+        methods={methods}
+        submitAssignment={submitAssignment}
+        isUpdate={action === ContentFormAction.muokkaus}
+        deleteModalState={{
+          openDeleteModal,
+          setOpenDeleteModal
+        }}
+        publishState={watchPublishState}
+        submitError={submitError}
+      />
     </>
   )
 }

--- a/web/src/components/forms/formCommon/FormButtonRow.tsx
+++ b/web/src/components/forms/formCommon/FormButtonRow.tsx
@@ -1,6 +1,5 @@
 import { Button } from '../../Button'
 import { Icon } from '../../Icon'
-import { useNavigate } from 'react-router-dom'
 import { PublishState } from '../../../types'
 import { useLudosTranslation } from '../../../hooks/useLudosTranslation'
 
@@ -13,7 +12,7 @@ type FormButtonRowProps = {
   }
   state: {
     isUpdate: boolean
-    isSubmitting: boolean
+    disableSubmit: boolean
     publishState?: PublishState
   }
   formHasValidationErrors: boolean
@@ -22,8 +21,7 @@ type FormButtonRowProps = {
 
 export const FormButtonRow = ({ actions, state, formHasValidationErrors, errorMessage }: FormButtonRowProps) => {
   const { t } = useLudosTranslation()
-  const navigate = useNavigate()
-  const { isUpdate, isSubmitting } = state
+  const { isUpdate, disableSubmit } = state
   const isDraft = state.publishState === PublishState.Draft
 
   const draftButtonText = () => {
@@ -57,7 +55,7 @@ export const FormButtonRow = ({ actions, state, formHasValidationErrors, errorMe
           <Button
             variant="buttonDanger"
             onClick={actions.onDeleteClick}
-            disabled={isSubmitting}
+            disabled={disableSubmit}
             data-testid="form-delete">
             {t('form.button.poista')}
           </Button>
@@ -68,14 +66,14 @@ export const FormButtonRow = ({ actions, state, formHasValidationErrors, errorMe
           variant="buttonGhost"
           onClick={actions.onCancelClick}
           customClass="w-full md:w-auto"
-          disabled={isSubmitting}
+          disabled={disableSubmit}
           data-testid="form-cancel">
           {t('button.peruuta')}
         </Button>
         <Button
           variant="buttonSecondary"
           customClass="w-full md:w-auto"
-          disabled={isSubmitting}
+          disabled={disableSubmit}
           onClick={actions.onSaveDraftClick}
           data-testid="form-draft">
           {draftButtonText()}
@@ -84,7 +82,7 @@ export const FormButtonRow = ({ actions, state, formHasValidationErrors, errorMe
           variant="buttonPrimary"
           onClick={actions.onSubmitClick}
           customClass="w-full md:w-auto"
-          disabled={isSubmitting}
+          disabled={disableSubmit}
           data-testid="form-submit">
           {submitButtonText()}
         </Button>

--- a/web/src/hooks/useAssignmentForm.tsx
+++ b/web/src/hooks/useAssignmentForm.tsx
@@ -1,5 +1,5 @@
 import { ContentFormAction, ContentType, ContentTypeSingularEng, Exam, PublishState } from '../types'
-import { useContext, useState } from 'react'
+import { useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { NotificationEnum, useNotification } from '../contexts/NotificationContext'
 import { createAssignment, fetchData, updateAssignment } from '../request'
@@ -11,26 +11,24 @@ import {
   CommonAssignmentFormType
 } from '../components/forms/schemas/assignmentSchema'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { FormButtonRow } from '../components/forms/formCommon/FormButtonRow'
 import { MultiValue } from 'react-select'
 import { LudosSelectOption } from '../components/ludosSelect/LudosSelect'
-import { DeleteModal } from '../components/modal/DeleteModal'
 import { useLudosTranslation } from './useLudosTranslation'
-import { LudosContext } from '../contexts/LudosContext'
 import { useFormPrompt } from './useFormPrompt'
 
-export function useAssignmentForm<T extends CommonAssignmentFormType>(exam: Exam, id: string | undefined) {
+export function useAssignmentForm<T extends CommonAssignmentFormType>(
+  exam: Exam,
+  id: string | undefined,
+  action: ContentFormAction
+) {
   const { lt, t } = useLudosTranslation()
-  const { uiLanguage } = useContext(LudosContext)
   const { state } = useLocation()
   const navigate = useNavigate()
   const { setNotification } = useNotification()
 
-  const [isSubmitting, setIsSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string>('')
   const [openDeleteModal, setOpenDeleteModal] = useState(false)
 
-  const action = id ? ContentFormAction.muokkaus : ContentFormAction.uusi
   const isUpdate = action === ContentFormAction.muokkaus
 
   async function defaultValues<T>(): Promise<T> {
@@ -112,7 +110,6 @@ export function useAssignmentForm<T extends CommonAssignmentFormType>(exam: Exam
       const assignment = { ...data, publishState }
 
       try {
-        setIsSubmitting(true)
         const resultId = await submitAssignmentData(assignment)
         setSubmitError('')
         handleSuccess(publishState, resultId)
@@ -120,45 +117,16 @@ export function useAssignmentForm<T extends CommonAssignmentFormType>(exam: Exam
         setSubmitError(e instanceof Error ? e.message || 'Unexpected error' : 'Unexpected error')
         setErrorNotification(publishState)
       } finally {
-        setIsSubmitting(false)
       }
     })()
   }
 
-  const handleCancelClick = () => navigate(-1)
-
-  const AssignmentFormButtonRow = ({ publishState }: { publishState?: PublishState }) => (
-    <>
-      <FormButtonRow
-        actions={{
-          onSubmitClick: () => submitAssignment(PublishState.Published),
-          onSaveDraftClick: () => submitAssignment(PublishState.Draft),
-          onDeleteClick: () => setOpenDeleteModal(true),
-          onCancelClick: handleCancelClick
-        }}
-        state={{
-          isUpdate,
-          isSubmitting,
-          publishState
-        }}
-        formHasValidationErrors={Object.keys(methods.formState.errors).length > 0}
-        errorMessage={submitError}
-      />
-      <DeleteModal
-        modalTitle={lt.contentDeleteModalTitle[ContentType.koetehtavat]}
-        open={openDeleteModal}
-        onDeleteAction={() => submitAssignment(PublishState.Deleted)}
-        onClose={() => setOpenDeleteModal(false)}>
-        <div className="h-[15vh] p-6">
-          <p>
-            {lt.contentDeleteModalText[ContentType.koetehtavat](
-              uiLanguage === 'fi' ? getValues().nameFi : getValues().nameSv
-            )}
-          </p>
-        </div>
-      </DeleteModal>
-    </>
-  )
-
-  return { methods, handleMultiselectOptionChange, AssignmentFormButtonRow, isSubmitting }
+  return {
+    methods,
+    handleMultiselectOptionChange,
+    submitAssignment,
+    submitError,
+    openDeleteModal,
+    setOpenDeleteModal
+  }
 }

--- a/web/src/hooks/useAssignmentForm.tsx
+++ b/web/src/hooks/useAssignmentForm.tsx
@@ -27,7 +27,7 @@ export function useAssignmentForm<T extends CommonAssignmentFormType>(
   const { setNotification } = useNotification()
 
   const [submitError, setSubmitError] = useState<string>('')
-  const [openDeleteModal, setOpenDeleteModal] = useState(false)
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
 
   const isUpdate = action === ContentFormAction.muokkaus
 
@@ -126,7 +126,7 @@ export function useAssignmentForm<T extends CommonAssignmentFormType>(
     handleMultiselectOptionChange,
     submitAssignment,
     submitError,
-    openDeleteModal,
-    setOpenDeleteModal
+    isDeleteModalOpen,
+    setIsDeleteModalOpen
   }
 }


### PR DESCRIPTION
Tavoitteena parantaa tehtävälomakkeen submit nappien koodia, koska kun submit nappi komponentti tuli useAssignmentForm hookista, toimi state/re-render hassusti siten että validaation onBlur tapahtuman aikana ei voinut klikata tallenna lomake nappia