### PR TITLE
Suomi.fi-laatutyökalut käyttöön palautteenjättölinkeissä (OPHLUDOS-167)

### DIFF
--- a/.github/actions/playwright/action.yml
+++ b/.github/actions/playwright/action.yml
@@ -81,9 +81,10 @@ runs:
         TESTIKAYTTAJA_YLLAPITAJA_PASSWORD: ${{ inputs.testikayttaja-yllapitaja-password }}
       run: yarn workspace playwright ${{ inputs.yarn-script }}
     - name: Calculate artifact name suffix
+      if: always()
       id: artifact-name-suffix
       shell: bash
-      run: echo artifact-name-suffix=$(echo ${{ inputs.yarn-script }} | sed 's/:/-/g') >> $GITHUB_OUTPUT
+      run: echo artifact-name-suffix=$(echo '${{ inputs.yarn-script }}' | sed 's/:/-/g') >> $GITHUB_OUTPUT
     - uses: actions/upload-artifact@v4
       if: always()
       with:

--- a/.github/workflows/build_test_push.yml
+++ b/.github/workflows/build_test_push.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Playwright
         uses: ./.github/actions/playwright
         with:
-          yarn-script: test:parallel_tests
+          yarn-script: 'test:parallel_tests'
           ludos-profiles: local
           testikayttaja-yllapitaja-username: ${{ secrets.TESTIKAYTTAJA_YLLAPITAJA_USERNAME }}
           testikayttaja-yllapitaja-password: ${{ secrets.TESTIKAYTTAJA_YLLAPITAJA_PASSWORD }}
@@ -135,7 +135,7 @@ jobs:
       - name: Playwright
         uses: ./.github/actions/playwright
         with:
-          yarn-script: test:non_parallel_tests
+          yarn-script: 'test:non_parallel_tests'
           ludos-profiles: local
           testikayttaja-yllapitaja-username: ${{ secrets.TESTIKAYTTAJA_YLLAPITAJA_USERNAME }}
           testikayttaja-yllapitaja-password: ${{ secrets.TESTIKAYTTAJA_YLLAPITAJA_PASSWORD }}

--- a/playwright/helpers.ts
+++ b/playwright/helpers.ts
@@ -124,7 +124,7 @@ export async function assertFailureNotification(page: Page, notificationLocalisa
   const errorNotification = page.getByTestId('notification-error')
   await expect(errorNotification).toBeVisible()
   await expect(errorNotification).toHaveText(
-    `error${notificationLocalisationKey}notification.error.link.laheta-palautetta-virheestaclose`
+    `error${notificationLocalisationKey}notification.error.link.laheta-palautetta-virheestaopen_in_newclose`
   )
 }
 

--- a/playwright/models/CertificateContentListModel.ts
+++ b/playwright/models/CertificateContentListModel.ts
@@ -1,0 +1,12 @@
+import { Page } from '@playwright/test'
+import { ContentType, Exam } from 'web/src/types'
+import { ContentListModel } from './ContentListModel'
+
+export class CertificateContentListModel extends ContentListModel {
+  constructor(
+    readonly page: Page,
+    readonly exam: Exam
+  ) {
+    super(page, exam, ContentType.todistukset)
+  }
+}

--- a/playwright/models/ContentListModel.ts
+++ b/playwright/models/ContentListModel.ts
@@ -1,15 +1,25 @@
-import { Page } from '@playwright/test'
+import { expect, Page } from '@playwright/test'
 import { ContentType, Exam } from 'web/src/types'
+import { setSingleSelectDropdownOption } from '../helpers'
+import { ContentTypeTabModel } from './ContentTypeTabModel'
 
 export class ContentListModel {
   constructor(
     readonly page: Page,
     readonly exam: Exam,
-    readonly contentType: ContentType // Maybe we should extend this by ContentType instead?
+    readonly contentType: ContentType, // Maybe we should extend this by ContentType instead?
+    readonly contentTypeTabs = new ContentTypeTabModel(page)
   ) {}
 
   async goto() {
     await this.page.getByTestId(`nav-link-${this.exam.toLowerCase()}`).click()
+    await expect(this.page.getByTestId(`page-heading-${this.exam.toLowerCase()}`)).toBeVisible()
     await this.page.getByTestId(`tab-${this.contentType}`).click()
+    await expect(this.contentTypeTabs.tab(this.contentType)).toHaveAttribute('aria-current')
+  }
+
+  async setOrder(direction: 'asc' | 'desc') {
+    await setSingleSelectDropdownOption(this.page, 'orderFilter', direction)
+    await this.page.waitForURL(new RegExp(`.*jarjesta=${direction}.*`))
   }
 }

--- a/playwright/models/ContentTypeTabModel.ts
+++ b/playwright/models/ContentTypeTabModel.ts
@@ -1,0 +1,10 @@
+import { Locator, Page } from '@playwright/test'
+import { ContentType } from 'web/src/types'
+
+export class ContentTypeTabModel {
+  constructor(readonly page: Page) {}
+
+  tab(contentType: ContentType): Locator {
+    return this.page.getByTestId(`tab-${contentType.toLowerCase()}`)
+  }
+}

--- a/playwright/models/LayoutModel.ts
+++ b/playwright/models/LayoutModel.ts
@@ -1,14 +1,22 @@
 import { Page } from '@playwright/test'
+import { BusinessLanguage } from 'web/src/types'
 
 export class LayoutModel {
   constructor(
     readonly page: Page,
     readonly languageDropdown = page.getByTestId('header-language-dropdown'),
-    readonly languageDropdownExpandButton = page.getByTestId('header-language-dropdown-expand')
+    readonly languageDropdownExpandButton = languageDropdown.getByTestId('header-language-dropdown-expand'),
+    readonly footer = page.getByTestId('footer'),
+    readonly footerFeedbackLink = footer.getByTestId('feedback-link')
   ) {}
+
+  async setUiLanguage(language: BusinessLanguage) {
+    await this.languageDropdownExpandButton.click()
+    await this.languageDropdown.getByTestId(language).click()
+  }
 
   async showLocalizationKeys() {
     await this.languageDropdownExpandButton.click()
-    await this.languageDropdown.getByText('Näytä avaimet').click()
+    await this.languageDropdown.getByTestId('keys').click()
   }
 }

--- a/playwright/parallel_tests/certificate/certificateForm.spec.ts
+++ b/playwright/parallel_tests/certificate/certificateForm.spec.ts
@@ -64,7 +64,7 @@ async function updateCertificate(
 }
 
 async function deleteCertificate(form: CertificateFormModel, certificateId: number) {
-  const { page, exam } = form
+  const { page } = form
 
   await expect(form.formHeader).toBeVisible()
 

--- a/playwright/parallel_tests/feedback.spec.ts
+++ b/playwright/parallel_tests/feedback.spec.ts
@@ -1,0 +1,47 @@
+import { expect, Locator, Page, test } from '@playwright/test'
+import { loginTestGroup, Role } from '../helpers'
+import { BusinessLanguage, Exam } from 'web/src/types'
+import { CertificateContentListModel } from '../models/CertificateContentListModel'
+import { LayoutModel } from '../models/LayoutModel'
+
+loginTestGroup(test, Role.OPETTAJA)
+
+test.describe('feedback link', async () => {
+  async function assertFeedbackLink(
+    page: Page,
+    feedbackLink: Locator,
+    expectedLanguage: BusinessLanguage,
+    lastHref: string
+  ): Promise<string> {
+    await expect(feedbackLink).toHaveAttribute('href', new RegExp(`.*ref=${encodeURIComponent(page.url())}.*`))
+    await expect(feedbackLink).toHaveAttribute('href', new RegExp(`.*language=${expectedLanguage}.*`))
+    const href = (await feedbackLink.getAttribute('href'))!
+    expect(href).not.toEqual(lastHref)
+    return href
+  }
+
+  test('footer feedback link works', async ({ page }) => {
+    await page.goto('/')
+    const layout = new LayoutModel(page)
+    let lastHref = await layout.footerFeedbackLink.getAttribute('href')
+    expect(lastHref).not.toBeFalsy()
+    const puhviCertificateContentList = new CertificateContentListModel(page, Exam.PUHVI)
+    await puhviCertificateContentList.goto()
+
+    await layout.setUiLanguage(BusinessLanguage.fi)
+    lastHref = await assertFeedbackLink(page, layout.footerFeedbackLink, BusinessLanguage.fi, lastHref!)
+
+    await puhviCertificateContentList.setOrder('asc')
+    lastHref = await assertFeedbackLink(page, layout.footerFeedbackLink, BusinessLanguage.fi, lastHref)
+
+    await puhviCertificateContentList.setOrder('desc')
+    lastHref = await assertFeedbackLink(page, layout.footerFeedbackLink, BusinessLanguage.fi, lastHref)
+
+    await layout.setUiLanguage(BusinessLanguage.sv)
+    await assertFeedbackLink(page, layout.footerFeedbackLink, BusinessLanguage.sv, lastHref)
+
+    await page.goto((await layout.footerFeedbackLink.getAttribute('href'))!) // avaa samaan tabiin
+    // Jostain syystä githubissa tulee aina virheilmoitus lomaakkeen latautumisen sijaan
+    await expect(page.getByText(/(Kundrespons om tjänsten LUDOS|Responsen kunde inte laddas)/)).toBeVisible()
+  })
+})

--- a/playwright/parallel_tests/homepage.spec.ts
+++ b/playwright/parallel_tests/homepage.spec.ts
@@ -4,7 +4,7 @@ import { ContentType } from 'web/src/types'
 
 const contentTypes = Object.values(ContentType)
 
-const pageIds = ['etusivu', 'suko', 'ld', 'puhvi', 'palautteet']
+const pageIds = ['etusivu', 'suko', 'ld', 'puhvi']
 
 loginTestGroup(test, Role.YLLAPITAJA)
 

--- a/playwright/parallel_tests/instruction/instructionPdfDownload.spec.ts
+++ b/playwright/parallel_tests/instruction/instructionPdfDownload.spec.ts
@@ -9,7 +9,7 @@ import { InstructionFormModel } from '../../models/InstructionFormModel'
 loginTestGroup(test, Role.YLLAPITAJA)
 Object.values(Exam).forEach((exam) => {
   test.describe(`${exam} instruction pdf download test`, () => {
-    test.beforeEach(async ({ page, context, baseURL }) => {
+    test.beforeEach(async ({ page, baseURL }) => {
       const form = new InstructionFormModel(page, exam)
       await initializeInstructionTest(page, exam)
       const instruction = await form.createInstructionApiCall(baseURL!, ['fixture1.pdf'])

--- a/playwright/parallel_tests/instruction/instructionVersionHistory.spec.ts
+++ b/playwright/parallel_tests/instruction/instructionVersionHistory.spec.ts
@@ -21,7 +21,7 @@ Object.values(Exam).forEach((exam) => {
 
       await versionHistory.createTestVersions(async (version) => {
         // In version 3, remove fixture1.pdf and add fixture2.pdf and fixture3.pdf
-        let currentAttachments: AttachmentDtoOut[] = []
+        let currentAttachments: AttachmentDtoOut[]
         if (version < 3) {
           currentAttachments = instruction.attachments
         } else if (version === 3) {

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -1,9 +1,8 @@
 import logo from 'web/assets/oph_fin_vaaka.png'
 import { ExternalLink } from './ExternalLink'
-import { InternalLink } from './InternalLink'
 import { OPH_URL, TIETOSUOJA_SELOSTE_URL, virkailijanOpintopolkuUrl } from '../constants'
 import { useTranslation } from 'react-i18next'
-import { feedbackPath } from './LudosRoutes'
+import { useFeedbackUrl } from '../hooks/useFeedbackUrl'
 
 type FooterProps = {
   isPresentation?: boolean
@@ -11,8 +10,10 @@ type FooterProps = {
 
 export const Footer = ({ isPresentation }: FooterProps) => {
   const { t } = useTranslation()
+  const feedbackUrl = useFeedbackUrl()
+
   return (
-    <div className="mt-5 border-t-2 border-gray-separator pb-4 pt-3">
+    <div className="mt-5 border-t-2 border-gray-separator pb-4 pt-3" data-testid="footer">
       <div className="flex flex-wrap md:px-10">
         <div className="flex w-full flex-col md:w-3/12">
           <div className="flex justify-center pb-5 pt-3">
@@ -25,7 +26,9 @@ export const Footer = ({ isPresentation }: FooterProps) => {
           <>
             <span className="hidden md:flex md:w-1/12 md:flex-col" />
             <div className="mt-3 flex w-1/3 flex-col text-center md:w-2/12 md:text-left">
-              <InternalLink to={feedbackPath()}>{t('footer.palaute')}</InternalLink>
+              <ExternalLink url={feedbackUrl} data-testid="feedback-link">
+                {t('footer.palaute')}
+              </ExternalLink>
             </div>
             <div className="mt-3 flex w-1/3 flex-col text-center md:w-2/12 md:text-left">
               <ExternalLink url={TIETOSUOJA_SELOSTE_URL}>{t('footer.tietosuoja')}</ExternalLink>

--- a/web/src/components/InfoBox.tsx
+++ b/web/src/components/InfoBox.tsx
@@ -1,8 +1,8 @@
 import { Icon } from './Icon'
 import { Trans, useTranslation } from 'react-i18next'
 import { twMerge } from 'tailwind-merge'
-import { InternalLink } from './InternalLink'
-import { palautteetKey } from './LudosRoutes'
+import { useFeedbackUrl } from '../hooks/useFeedbackUrl'
+import { ExternalLink } from './ExternalLink'
 
 type InfoBoxProps = {
   type: 'info' | 'error'
@@ -11,6 +11,7 @@ type InfoBoxProps = {
 
 export const InfoBox = ({ type, i18nKey }: InfoBoxProps) => {
   const { t } = useTranslation()
+  const feedbackUrl = useFeedbackUrl()
   const isError = type === 'error'
 
   return (
@@ -29,9 +30,9 @@ export const InfoBox = ({ type, i18nKey }: InfoBoxProps) => {
       <p className="flex-grow">
         <Trans i18nKey={i18nKey} />
         {isError && (
-          <InternalLink className="ml-1 text-white underline" to={`/${palautteetKey}`}>
+          <ExternalLink className="ml-1 underline" textColor="text-white" url={feedbackUrl}>
             {t('notification.error.link.laheta-palautetta-virheesta')}
-          </InternalLink>
+          </ExternalLink>
         )}
       </p>
     </div>

--- a/web/src/components/LudosRoutes.tsx
+++ b/web/src/components/LudosRoutes.tsx
@@ -21,7 +21,6 @@ import { ReauthorizeSuccessful } from './ReauthorizeSuccessful'
 export const etusivuKey = 'etusivu'
 export const uusiKey: ContentFormAction = ContentFormAction.uusi
 export const muokkausKey: ContentFormAction = ContentFormAction.muokkaus
-export const palautteetKey = 'palautteet'
 export const sukoKey = Exam.SUKO.toLowerCase()
 export const puhviKey = Exam.PUHVI.toLowerCase()
 export const ldKey = Exam.LD.toLowerCase()
@@ -32,8 +31,6 @@ export const uudelleenkirjautuminenOnnistuiPath = '/uudelleenkirjautuminen-onnis
 export const frontpagePath = () => '/'
 
 export const examPath = (exam: Exam) => `/${exam.toLowerCase()}`
-
-export const feedbackPath = () => `/${palautteetKey}`
 
 export const contentPagePath = (exam: Exam, contentType: ContentType, id: number, version?: number) =>
   `${examPath(exam)}/${contentType}/${id}${version ? `/${version}` : ''}`
@@ -82,15 +79,6 @@ const YllapitajaRoute = (): ReactElement => {
   return <Outlet />
 }
 
-const Palautteet = () => {
-  const { t } = useTranslation()
-  return (
-    <div>
-      <h2 data-testid={`page-heading-${palautteetKey}`}>{t('title.palautteet')}</h2>
-    </div>
-  )
-}
-
 const DefaultError = () => {
   const { t } = useTranslation()
   let error = useRouteError()
@@ -130,19 +118,6 @@ export const ludosRouter = createBrowserRouter([
             <AssignmentFavorite />
           </Layout>
         )
-      },
-      {
-        element: <YllapitajaRoute />,
-        children: [
-          {
-            path: `/${palautteetKey}`,
-            element: (
-              <Layout>
-                <Palautteet />
-              </Layout>
-            )
-          }
-        ]
       },
       {
         path: uudelleenkirjautuminenOnnistuiPath,

--- a/web/src/components/Notification.tsx
+++ b/web/src/components/Notification.tsx
@@ -3,14 +3,15 @@ import { twMerge } from 'tailwind-merge'
 import { Icon } from './Icon'
 import { Button } from './Button'
 import { NotificationEnum, useNotification } from '../contexts/NotificationContext'
-import { InternalLink } from './InternalLink'
 import { useTranslation } from 'react-i18next'
-import { palautteetKey } from './LudosRoutes'
+import { useFeedbackUrl } from '../hooks/useFeedbackUrl'
+import { ExternalLink } from './ExternalLink'
 
 const NOTIFICATION_TIMEOUT_MS = 5000
 
 export const Notification = () => {
   const { t } = useTranslation()
+  const feedbackUrl = useFeedbackUrl()
   const { notification, setNotification } = useNotification()
   const hideNotification = useCallback(() => setNotification(null), [setNotification])
 
@@ -39,9 +40,9 @@ export const Notification = () => {
           {notification.type === NotificationEnum.error && (
             <>
               {notification.linkComponent || (
-                <InternalLink className="text-white underline" to={`/${palautteetKey}`}>
+                <ExternalLink className="underline" textColor="text-white" url={feedbackUrl}>
                   {t('notification.error.link.laheta-palautetta-virheesta')}
-                </InternalLink>
+                </ExternalLink>
               )}
             </>
           )}

--- a/web/src/components/header/Header.tsx
+++ b/web/src/components/header/Header.tsx
@@ -2,18 +2,7 @@ import { useMediaQuery } from '../../hooks/useMediaQuery'
 import { IS_MOBILE_QUERY } from '../../constants'
 import { HeaderMobile } from './HeaderMobile'
 import { HeaderDesktop } from './HeaderDesktop'
-import { useUserDetails } from '../../hooks/useUserDetails'
-import {
-  contentListPath,
-  etusivuKey,
-  examPath,
-  feedbackPath,
-  frontpagePath,
-  ldKey,
-  palautteetKey,
-  puhviKey,
-  sukoKey
-} from '../LudosRoutes'
+import { contentListPath, etusivuKey, examPath, frontpagePath, ldKey, puhviKey, sukoKey } from '../LudosRoutes'
 import { ContentType, Exam } from '../../types'
 import { useTranslation } from 'react-i18next'
 
@@ -27,7 +16,6 @@ export interface HeaderPage {
 export const Header = () => {
   const { t } = useTranslation()
   const isMobile = useMediaQuery({ query: IS_MOBILE_QUERY })
-  const { isYllapitaja } = useUserDetails()
 
   const pages: HeaderPage[] = [
     {
@@ -52,18 +40,11 @@ export const Header = () => {
       localizationText: t('header.puhvi'),
       path: examPath(Exam.PUHVI),
       navigateTo: contentListPath(Exam.PUHVI, ContentType.koetehtavat)
-    },
-    {
-      key: `${palautteetKey}`,
-      localizationText: t('header.palautteet'),
-      path: feedbackPath()
     }
   ]
-  const filteredPages = isYllapitaja ? pages : pages.filter((page) => page.path !== `/${palautteetKey}`)
-
   if (isMobile) {
-    return <HeaderMobile pages={filteredPages} />
+    return <HeaderMobile pages={pages} />
   }
 
-  return <HeaderDesktop pages={filteredPages} />
+  return <HeaderDesktop pages={pages} />
 }

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -1,4 +1,5 @@
 export const OPH_URL = 'https://oph.fi/'
+export const FEEDBACK_BASE_URL = 'https://laatutyokalut.suomi.fi/p/hcTd'
 export const BASE_API_URL = '/api'
 export const ASSIGNMENT_URL = `${BASE_API_URL}/assignment`
 export const INSTRUCTION_URL = `${BASE_API_URL}/instruction`

--- a/web/src/hooks/useFeedbackUrl.ts
+++ b/web/src/hooks/useFeedbackUrl.ts
@@ -1,0 +1,16 @@
+import { useContext } from 'react'
+import { LudosContext } from '../contexts/LudosContext'
+import { FEEDBACK_BASE_URL } from '../constants'
+import { useLocation } from 'react-router-dom'
+
+export const useFeedbackUrl = () => {
+  const { uiLanguage } = useContext(LudosContext)
+  const { pathname, search, hash } = useLocation()
+
+  const feedbackParams = new URLSearchParams({
+    ref: `${window.location.origin}${pathname}${search}${hash}`,
+    language: uiLanguage
+  })
+
+  return `${FEEDBACK_BASE_URL}?${feedbackParams.toString()}`
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -230,8 +230,6 @@ type Metadata = {
   language: AttachmentLanguage
 }
 
-export type MapWithFileKeyAndMetadata = Map<string, Metadata>
-
 export type AttachmentLanguage = 'fi' | 'sv'
 
 export type AttachmentData = {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -200,15 +200,15 @@ export const BusinessLanguage = {
   fi: 'fi',
   sv: 'sv',
   en: 'en'
-}
+} as const
 
-export type BusinessLanguageType = keyof typeof BusinessLanguage
+export type BusinessLanguage = keyof typeof BusinessLanguage
 
 export type UserDetails = {
   firstNames: string | null
   lastName: string | null
   role: RolesType | null
-  businessLanguage: BusinessLanguageType | null
+  businessLanguage: BusinessLanguage | null
 }
 
 export const ErrorMessages = {


### PR DESCRIPTION
TODO:
- [x] Playwright-testit formin aukeamiselle ja kielen välittymiselle.

Palautelinkki vaihdettu footeriin, toasteihin ja infoboxeihin. Linkin mukana välitetään palautelomakkeelle nykyisen sivun koko URL ja UI-kieli.
![image](https://github.com/Opetushallitus/ludos/assets/1202380/2b39fb9e-cb4e-4373-ae63-b7d7950824db)
