### PR TITLE
OPHLUDOS-161 & 178: Suodattimet single select malliseksi ja tyhjennä filtterit nappi lisätty

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ Vaihtoehtoja backendin ajamiseen:
 2) Aja `LudosApplication.kt`:n main-metodi IDEAsta. Lisää run configurationiin halutut profiilit, esim. `local` ja lisää working directory `server`
 3) `SPRING_PROFILES_ACTIVE=local server/gradlew bootRun -p server bootRun`
 4) `server/gradlew build -p server -x test && LUDOS_PROFILES=local docker-build/run.sh`
-  * Tää buildaa myös frontendin, joka tarjoillaan https://localhost:8080/:sta spring
-    bootin kautta kuten tuotannossa.
-  * 8080-portissa frontti ei kuitenkaan päivity itsestään vaikka `yarn dev` ois päällä
-    `web`-kansiossa, vaan siellä on ajettava `yarn build` erikseen joka kerta.
-  * Fronttia devatessa onkin suositeltavaa ajaa `web`-kansiossa `yarn dev` ja
-    käyttää selaimessa porttia `8000` eikä `8080` niin autoreloadid yms toimii
+   * Tää buildaa myös frontendin, joka tarjoillaan https://localhost:8080/:sta spring
+     bootin kautta kuten tuotannossa.
+   * 8080-portissa frontti ei kuitenkaan päivity itsestään vaikka `yarn dev` ois päällä
+     `web`-kansiossa, vaan siellä on ajettava `yarn build` erikseen joka kerta.
+   * Fronttia devatessa onkin suositeltavaa ajaa `web`-kansiossa `yarn dev` ja
+     käyttää selaimessa porttia `8000` eikä `8080` niin autoreloadid yms toimii
 5) `build:docker` + `run:docker` (profiili kovakoodattu `local`)
 
 ### Frontend

--- a/playwright/non_parallel_tests/assignment/assignmentList.spec.ts
+++ b/playwright/non_parallel_tests/assignment/assignmentList.spec.ts
@@ -49,7 +49,7 @@ test.describe('Assignment filter tests', () => {
 
     await assertStartPage()
 
-    await setMultiSelectDropdownOptions(page, 'oppimaaraFilter', ['VKA1', 'VKA1.RA'])
+    await setMultiSelectDropdownOptions(page, 'oppimaaraFilter', ['VKA1'])
     await setMultiSelectDropdownOptions(page, 'contentTypeFilter', ['003']) // keskustelu
     await setMultiSelectDropdownOptions(page, 'aiheFilter', ['013']) // pohjoismaat
 

--- a/server/src/main/kotlin/fi/oph/ludos/assignment/Assignment.kt
+++ b/server/src/main/kotlin/fi/oph/ludos/assignment/Assignment.kt
@@ -21,6 +21,17 @@ data class Oppimaara(
     val oppimaaraKoodiArvo: String,
     val kielitarjontaKoodiArvo: String? = null
 ) : Comparable<Oppimaara> {
+    companion object {
+        fun fromString(oppimaaraString: String): Oppimaara {
+            val parts = oppimaaraString.split(".")
+            return when (parts.size) {
+                1 -> Oppimaara(parts[0])
+                2 -> Oppimaara(parts[0], parts[1])
+                else -> throw IllegalArgumentException("Invalid oppimaaraString: $oppimaaraString")
+            }
+        }
+    }
+
     override fun compareTo(other: Oppimaara): Int {
         val oppimaaraOrder = oppimaaraKoodiArvo.compareTo(other.oppimaaraKoodiArvo)
         return if (oppimaaraOrder != 0) {
@@ -32,7 +43,6 @@ data class Oppimaara(
         } else {
             kielitarjontaKoodiArvo.compareTo(other.kielitarjontaKoodiArvo)
         }
-
     }
 }
 

--- a/server/src/main/kotlin/fi/oph/ludos/auth/Kayttajatiedot.kt
+++ b/server/src/main/kotlin/fi/oph/ludos/auth/Kayttajatiedot.kt
@@ -1,6 +1,5 @@
 package fi.oph.ludos.auth
 
-import org.slf4j.spi.LoggingEventBuilder
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.core.userdetails.UserDetails

--- a/server/src/main/kotlin/fi/oph/ludos/aws/AwsCommon.kt
+++ b/server/src/main/kotlin/fi/oph/ludos/aws/AwsCommon.kt
@@ -7,7 +7,7 @@ import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider
 import software.amazon.awssdk.regions.Region
 
 
-val AWS_REGION = Region.EU_WEST_1
+val AWS_REGION: Region = Region.EU_WEST_1
 fun awsCredentialsProviderChain(localAwsProfileName: String?): AwsCredentialsProviderChain {
 
     val providerChain = AwsCredentialsProviderChain.builder()

--- a/server/src/main/resources/fixtures/this-will-fail.txt
+++ b/server/src/main/resources/fixtures/this-will-fail.txt
@@ -1,1 +1,1 @@
-This file is for testing failing a attachment upload.
+This file is for testing failing an attachment upload.

--- a/server/src/test/kotlin/fi/oph/ludos/instruction/InstructionControllerTest.kt
+++ b/server/src/test/kotlin/fi/oph/ludos/instruction/InstructionControllerTest.kt
@@ -319,12 +319,11 @@ class InstructionControllerTest : InstructionRequests() {
 
     private fun assertFilteredLdInstructionList(
         filters: LdInstructionFilters,
-        expectedSize: Int,
         expectedNumbersInList: List<Int>,
         expectedAineOptions: List<Int>
     ) {
         val instructionsOut: LdInstructionListDtoOut = getAllInstructions(filters)
-        assertEquals(expectedSize, instructionsOut.content.size)
+        assertEquals(expectedNumbersInList.size, instructionsOut.content.size)
         assertTrue(
             instructionsOut.content.all { it.exam == Exam.LD },
             "Wrong exam in list, expected: ${Exam.LD}, got ${instructionsOut.content.map { it.exam }}"
@@ -365,12 +364,21 @@ class InstructionControllerTest : InstructionRequests() {
             aine = null
         )
 
-        assertFilteredLdInstructionList(filters, 8, listOf(4, 5, 6, 7, 8, 9, 10, 11), listOf(1, 2, 3, 5, 6, 7, 8, 9))
-        assertFilteredLdInstructionList(filters.copy(aine = "1"), 1, listOf(9), listOf(1))
-        assertFilteredLdInstructionList(filters.copy(aine = "9"), 1, listOf(8), listOf(9))
-        assertFilteredLdInstructionList(filters.copy(aine = "1,9"), 2, listOf(8, 9), listOf(1, 9))
-        assertFilteredLdInstructionList(filters.copy(jarjesta = "desc", aine = "1,9"), 2, listOf(9, 8), listOf(1, 9))
-        assertFilteredLdInstructionList(filters.copy(jarjesta = null, aine = "1,9"), 2, listOf(8, 9), listOf(1, 9))
+        val allPubAineKoodiArvos = listOf(1, 2, 3, 5, 6, 7, 8, 9)
+        assertFilteredLdInstructionList(filters, listOf(4, 5, 6, 7, 8, 9, 10, 11), allPubAineKoodiArvos)
+        assertFilteredLdInstructionList(filters.copy(aine = "1"), listOf(9), allPubAineKoodiArvos)
+        assertFilteredLdInstructionList(filters.copy(aine = "9"), listOf(8), allPubAineKoodiArvos)
+        assertFilteredLdInstructionList(filters.copy(aine = "1,9"), listOf(8, 9), allPubAineKoodiArvos)
+        assertFilteredLdInstructionList(
+            filters.copy(jarjesta = "desc", aine = "1,9"),
+            listOf(9, 8),
+            allPubAineKoodiArvos
+        )
+        assertFilteredLdInstructionList(
+            filters.copy(jarjesta = null, aine = "1,9"),
+            listOf(8, 9),
+            allPubAineKoodiArvos
+        )
     }
 
     @Test

--- a/server/versions.properties
+++ b/server/versions.properties
@@ -45,8 +45,6 @@ version.com.fasterxml.jackson.module..jackson-module-kotlin=2.16.1
 
 version.com.fasterxml.jackson.datatype..jackson-datatype-jsr310=2.16.1
 
-version.ch.qos.logback:logback-access=1.4.14
-
 version.net.logstash.logback..logstash-logback-encoder=7.4
 
 plugin.org.springframework.boot=3.2.2

--- a/web/src/components/content/list/assignment/AssignmentFilters.tsx
+++ b/web/src/components/content/list/assignment/AssignmentFilters.tsx
@@ -5,12 +5,13 @@ import { AssignmentFilterOptions, Exam, Oppimaara, oppimaaraFromId } from '../..
 import { koodisOrDefaultLabel, useKoodisto } from '../../../../hooks/useKoodisto'
 import { LudosSelect, LudosSelectOption } from '../../../ludosSelect/LudosSelect'
 import {
-  currentKoodistoSelectOptions,
-  currentOppimaaraSelectOptions,
+  currentKoodistoSelectOption,
+  currentOppimaaraSelectOption,
   koodistoSelectOptions,
   oppimaaraSelectOptions
 } from '../../../ludosSelect/helpers'
-import { MultiValue } from 'react-select'
+import { SingleValue } from 'react-select'
+import { Button } from '../../../Button'
 
 type AssignmentFiltersProps = {
   exam: Exam
@@ -38,19 +39,16 @@ function ensureTarkentamattomatPaaoppimaarasAreIncluded(oppimaaras: Oppimaara[])
 
 export const AssignmentFilters = ({
   exam,
-  filterValues: { filterValues, setFilterValue },
+  filterValues: { filterValues, setFilterValue, resetFilterValues },
   assignmentFilterOptions
 }: AssignmentFiltersProps) => {
   const { t } = useTranslation()
   const { koodistos, getKoodiLabel, getOppimaaraLabel, sortKooditAlphabetically } = useKoodisto()
 
-  const handleMultiselectFilterChange = useCallback(
-    (key: keyof FiltersType, value: MultiValue<LudosSelectOption>) => {
-      setFilterValue(
-        key,
-        value.map((it) => it.value),
-        true
-      )
+  const handleFilterChange = useCallback(
+    (key: keyof FiltersType, value: SingleValue<LudosSelectOption>) => {
+      const filterValue = value?.value || null
+      setFilterValue(key, filterValue, true)
     },
     [setFilterValue]
   )
@@ -87,10 +85,13 @@ export const AssignmentFilters = ({
                 name="oppimaaraFilter"
                 menuSize="lg"
                 options={oppimaaraSelectOptions(oppimaaraOptions, getKoodiLabel)}
-                value={currentOppimaaraSelectOptions(filterValues.oppimaara?.map(oppimaaraFromId), getOppimaaraLabel)}
-                onChange={(opt) => handleMultiselectFilterChange('oppimaara', opt)}
-                isMulti
+                value={currentOppimaaraSelectOption(
+                  filterValues.oppimaara ? oppimaaraFromId(filterValues.oppimaara) : undefined,
+                  getOppimaaraLabel
+                )}
+                onChange={(opt) => handleFilterChange('oppimaara', opt)}
                 isSearchable
+                isClearable
               />
             </div>
             <div className="w-full px-2 md:w-6/12 lg:w-3/12">
@@ -99,10 +100,10 @@ export const AssignmentFilters = ({
                 name="contentTypeFilter"
                 menuSize="md"
                 options={koodistoSelectOptions(sortKooditAlphabetically(tehtavatyyppiSukoOptions))}
-                value={currentKoodistoSelectOptions(filterValues.tehtavatyyppisuko, koodistos['tehtavatyyppisuko'])}
-                onChange={(opt) => handleMultiselectFilterChange('tehtavatyyppisuko', opt)}
-                isMulti
+                value={currentKoodistoSelectOption(filterValues.tehtavatyyppisuko, koodistos['tehtavatyyppisuko'])}
+                onChange={(opt) => handleFilterChange('tehtavatyyppisuko', opt)}
                 isSearchable
+                isClearable
               />
             </div>
             <div className="w-full px-2 lg:w-3/12">
@@ -111,10 +112,10 @@ export const AssignmentFilters = ({
                 name="aiheFilter"
                 menuSize="md"
                 options={koodistoSelectOptions(sortKooditAlphabetically(aiheOptions))}
-                value={currentKoodistoSelectOptions(filterValues.aihe, koodistos['aihesuko'])}
-                onChange={(opt) => handleMultiselectFilterChange('aihe', opt)}
-                isMulti
+                value={currentKoodistoSelectOption(filterValues.aihe, koodistos['aihesuko'])}
+                onChange={(opt) => handleFilterChange('aihe', opt)}
                 isSearchable
+                isClearable
               />
             </div>
             {/* OPHLUDOS-125: https://jira.eduuni.fi/browse/OPHLUDOS-125 */}
@@ -137,10 +138,10 @@ export const AssignmentFilters = ({
             <LudosSelect
               name="lukuvuosiFilter"
               options={koodistoSelectOptions(sortKooditAlphabetically(lukuvuosiOptions))}
-              value={currentKoodistoSelectOptions(filterValues.lukuvuosi, koodistos['ludoslukuvuosi'])}
-              onChange={(opt) => handleMultiselectFilterChange('lukuvuosi', opt)}
-              isMulti
+              value={currentKoodistoSelectOption(filterValues.lukuvuosi, koodistos['ludoslukuvuosi'])}
+              onChange={(opt) => handleFilterChange('lukuvuosi', opt)}
               isSearchable
+              isClearable
             />
           </div>
         )}
@@ -150,10 +151,10 @@ export const AssignmentFilters = ({
             <LudosSelect
               name="aineFilter"
               options={koodistoSelectOptions(sortKooditAlphabetically(lukiodiplomiaineOptions))}
-              value={currentKoodistoSelectOptions(filterValues.aine, koodistos['ludoslukiodiplomiaine'])}
-              onChange={(opt) => handleMultiselectFilterChange('aine', opt)}
-              isMulti
+              value={currentKoodistoSelectOption(filterValues.aine, koodistos['ludoslukiodiplomiaine'])}
+              onChange={(opt) => handleFilterChange('aine', opt)}
               isSearchable
+              isClearable
             />
           </div>
         )}
@@ -163,13 +164,18 @@ export const AssignmentFilters = ({
             <LudosSelect
               name="tehtavatyyppiPuhviFilter"
               options={koodistoSelectOptions(sortKooditAlphabetically(tehtavatyyppiPuhviOptions))}
-              value={currentKoodistoSelectOptions(filterValues.tehtavatyyppipuhvi, koodistos['tehtavatyyppipuhvi'])}
-              onChange={(opt) => handleMultiselectFilterChange('tehtavatyyppipuhvi', opt)}
-              isMulti
+              value={currentKoodistoSelectOption(filterValues.tehtavatyyppipuhvi, koodistos['tehtavatyyppipuhvi'])}
+              onChange={(opt) => handleFilterChange('tehtavatyyppipuhvi', opt)}
               isSearchable
+              isClearable
             />
           </div>
         )}
+        <div className="flex items-end w-full md:w-3/12">
+          <Button variant="buttonGhost" onClick={resetFilterValues}>
+            <span className="text-green-primary text-xs">{t('filter.tyhjenna-valinnat')}</span>
+          </Button>
+        </div>
       </div>
     </div>
   )

--- a/web/src/components/content/list/assignment/AssignmentListHeader.tsx
+++ b/web/src/components/content/list/assignment/AssignmentListHeader.tsx
@@ -16,7 +16,7 @@ type AssignmentListHeaderProps = {
 
 export const AssignmentListHeader = ({ exam, filterValues }: AssignmentListHeaderProps) => {
   const { isYllapitaja } = useUserDetails()
-  const { t, lt } = useLudosTranslation()
+  const { t } = useLudosTranslation()
 
   const shouldShowTeachingLanguageDropdown = exam !== Exam.SUKO
 

--- a/web/src/components/content/list/instruction/InstructionList.tsx
+++ b/web/src/components/content/list/instruction/InstructionList.tsx
@@ -20,10 +20,10 @@ import { preventLineBreaksFromSpace } from '../../../../utils/formatUtils'
 import { ContentOrderFilter } from '../ContentOrderFilter'
 import { useUserDetails } from '../../../../hooks/useUserDetails'
 import { LudosSelect, LudosSelectOption } from '../../../ludosSelect/LudosSelect'
-import { currentKoodistoSelectOptions, koodistoSelectOptions } from '../../../ludosSelect/helpers'
+import { currentKoodistoSelectOption, koodistoSelectOptions } from '../../../ludosSelect/helpers'
 import { koodisOrDefaultLabel, useKoodisto } from '../../../../hooks/useKoodisto'
 import { useCallback, useContext } from 'react'
-import { MultiValue } from 'react-select'
+import { SingleValue } from 'react-select'
 import { LudosContext } from '../../../../contexts/LudosContext'
 import { InfoBox } from '../../../InfoBox'
 import { useLudosTranslation } from '../../../../hooks/useLudosTranslation'
@@ -58,13 +58,10 @@ export const InstructionList = ({ exam, filterValues: { filterValues, setFilterV
     ).toString()}`
   )
 
-  const handleMultiselectFilterChange = useCallback(
-    (key: keyof FiltersType, value: MultiValue<LudosSelectOption>) => {
-      setFilterValue(
-        key,
-        value.map((it) => it.value),
-        true
-      )
+  const handleFilterChange = useCallback(
+    (key: keyof FiltersType, value: SingleValue<LudosSelectOption>) => {
+      const filterValue = value?.value || null
+      setFilterValue(key, filterValue, true)
     },
     [setFilterValue]
   )
@@ -103,10 +100,10 @@ export const InstructionList = ({ exam, filterValues: { filterValues, setFilterV
                   koodisOrDefaultLabel(data?.instructionFilterOptions.aine || [], koodistos.ludoslukiodiplomiaine)
                 )
               )}
-              value={currentKoodistoSelectOptions(filterValues.aine, koodistos['ludoslukiodiplomiaine'])}
-              onChange={(opt) => handleMultiselectFilterChange('aine', opt)}
-              isMulti
+              value={currentKoodistoSelectOption(filterValues.aine, koodistos['ludoslukiodiplomiaine'])}
+              onChange={(opt) => handleFilterChange('aine', opt)}
               isSearchable
+              isClearable
             />
           </div>
         </div>

--- a/web/src/components/ludosSelect/helpers.ts
+++ b/web/src/components/ludosSelect/helpers.ts
@@ -92,14 +92,3 @@ export function currentOppimaaraSelectOption(
     label: getOppimaaraLabel(selectedOppimaaraOption)
   }
 }
-
-export function currentOppimaaraSelectOptions(
-  selectedOppimaaraOptions: Oppimaara[] | undefined,
-  getOppimaaraLabel: (oppimaara: Oppimaara) => string
-): LudosSelectOption[] {
-  if (!selectedOppimaaraOptions) {
-    return []
-  }
-
-  return selectedOppimaaraOptions.map((o) => currentOppimaaraSelectOption(o, getOppimaaraLabel)!)
-}

--- a/web/src/hooks/useFilterValues.ts
+++ b/web/src/hooks/useFilterValues.ts
@@ -3,14 +3,14 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { Exam } from '../types'
 
 export type FiltersType = {
-  oppimaara: string[] | null
-  tehtavatyyppisuko: string[] | null
-  aihe: string[] | null
-  tavoitetaitotaso: string[] | null
+  oppimaara: string | null
+  tehtavatyyppisuko: string | null
+  aihe: string | null
+  tavoitetaitotaso: string | null
   jarjesta: 'asc' | 'desc'
-  lukuvuosi: string[] | null
-  aine: string[] | null
-  tehtavatyyppipuhvi: string[] | null
+  lukuvuosi: string | null
+  aine: string | null
+  tehtavatyyppipuhvi: string | null
   sivu: number
 }
 
@@ -22,6 +22,7 @@ export type FilterValues = {
   filterValues: FiltersType
   setFilterValue: (key: keyof FiltersType, value: ParamsValue, replace: boolean) => void
   searchStringForNewFilterValue: (key: keyof FiltersType, value: ParamsValue) => string
+  resetFilterValues: () => void
 }
 
 export function useFilterValues(exam: Exam) {
@@ -56,7 +57,7 @@ export function useFilterValues(exam: Exam) {
       } else if (key === 'sivu') {
         currentParams[key] = Number(value)
       } else if (examKeyMap[exam]?.includes(key)) {
-        currentParams[key] = value.split(',')
+        currentParams[key] = value
       }
     })
 
@@ -94,5 +95,7 @@ export function useFilterValues(exam: Exam) {
     navigate({ search: searchStringForNewFilterValue(key, value) }, { replace })
   }
 
-  return { filterValues, setFilterValue, searchStringForNewFilterValue }
+  const resetFilterValues = () => navigate({ search: '' }, { replace: true })
+
+  return { filterValues, setFilterValue, searchStringForNewFilterValue, resetFilterValues }
 }


### PR DESCRIPTION
[OPHLUDOS-161](https://jira.eduuni.fi/browse/OPHLUDOS-161)
[OPHLUDOS-178](https://jira.eduuni.fi/browse/OPHLUDOS-178)

En koskenu tässä bäkkäriin. Periaatteessa siellä voi muuttaa queryjen luonti funkkarit olettamaan että ei tule stringgejä jossa monta esim ainetta.