### PR TITLE
OPHLUDOS-157: Matomo-käyttöönotto

### DIFF
--- a/playwright/auth.setup.ts
+++ b/playwright/auth.setup.ts
@@ -1,5 +1,6 @@
 import { expect, test as setup } from '@playwright/test'
 import { authFileByRole, login, Role } from './helpers'
+import { LayoutModel } from './models/LayoutModel'
 
 Object.values(Role).forEach((role: Role) => {
   setup(`authenticate as ${role}`, async ({ page }) => {
@@ -8,6 +9,7 @@ Object.values(Role).forEach((role: Role) => {
     if (role === Role.UNAUTHORIZED) {
       await expect(page.getByTestId('unauthorizedPage')).toBeVisible()
     } else {
+      await new LayoutModel(page).acceptOnlyNecessaryCookies()
       const expectedRoleText = role === Role.YLLAPITAJA ? 'ylläpitäjä' : 'opettaja'
       await expect(page.getByTestId('header-user-role')).toHaveText(expectedRoleText)
     }

--- a/playwright/models/LayoutModel.ts
+++ b/playwright/models/LayoutModel.ts
@@ -6,12 +6,19 @@ export class LayoutModel {
   constructor(
     readonly page: Page,
     readonly languageDropdown = page.getByTestId('header-language-dropdown'),
+    readonly headerEtusivu = page.getByTestId('nav-link-etusivu'),
+    readonly headerSuko = page.getByTestId('nav-link-suko'),
+    readonly headerLd = page.getByTestId('nav-link-ld'),
+    readonly headerPuhvi = page.getByTestId('nav-link-puhvi'),
     readonly footer = page.getByTestId('footer'),
     readonly footerFeedbackLink = footer.getByTestId('feedback-link'),
     readonly consentModal = page.getByTestId('consent-modal'),
     readonly consentModalSettingsButton = consentModal.getByTestId('settings-button'),
     readonly consentModalAcceptSelectedButton = consentModal.getByTestId('accept-selected-button'),
-    readonly consentModalAcceptAllButton = consentModal.getByTestId('accept-all-button')
+    readonly consentModalAcceptAllButton = consentModal.getByTestId('accept-all-button'),
+    readonly consentModalTrackingCheckbox = consentModal.getByTestId('consent-tracking-checkbox'),
+    readonly consentModalFooterButton = footer.getByTestId('privacy-settings-button'),
+    readonly partialMatomoAnalyticsUrl = 'analytiikka.opintopolku.fi/matomo/matomo.php?action_name=LUDOS'
   ) {}
 
   async setUiLanguage(language: Language) {
@@ -24,6 +31,10 @@ export class LayoutModel {
 
   async navHeaderGoToPageByExam(exam: string) {
     await this.page.getByTestId(`nav-link-${exam.toLowerCase()}`).click()
+  }
+
+  async acceptAllCookies() {
+    await this.consentModalAcceptAllButton.click()
   }
 
   async acceptOnlyNecessaryCookies() {

--- a/playwright/models/LayoutModel.ts
+++ b/playwright/models/LayoutModel.ts
@@ -7,7 +7,11 @@ export class LayoutModel {
     readonly page: Page,
     readonly languageDropdown = page.getByTestId('header-language-dropdown'),
     readonly footer = page.getByTestId('footer'),
-    readonly footerFeedbackLink = footer.getByTestId('feedback-link')
+    readonly footerFeedbackLink = footer.getByTestId('feedback-link'),
+    readonly consentModal = page.getByTestId('consent-modal'),
+    readonly consentModalSettingsButton = consentModal.getByTestId('settings-button'),
+    readonly consentModalAcceptSelectedButton = consentModal.getByTestId('accept-selected-button'),
+    readonly consentModalAcceptAllButton = consentModal.getByTestId('accept-all-button')
   ) {}
 
   async setUiLanguage(language: Language) {
@@ -20,5 +24,10 @@ export class LayoutModel {
 
   async navHeaderGoToPageByExam(exam: string) {
     await this.page.getByTestId(`nav-link-${exam.toLowerCase()}`).click()
+  }
+
+  async acceptOnlyNecessaryCookies() {
+    await this.consentModalSettingsButton.click()
+    await this.consentModalAcceptSelectedButton.click()
   }
 }

--- a/playwright/non_parallel_tests/cas_auth/login.spec.ts
+++ b/playwright/non_parallel_tests/cas_auth/login.spec.ts
@@ -1,3 +1,5 @@
+import { LayoutModel } from '../../models/LayoutModel'
+
 require('dotenv').config({ path: '.env' })
 import { expect, test } from '@playwright/test'
 
@@ -17,6 +19,7 @@ test('yllapitaja can login and logout', async ({ page }) => {
   await page.locator('#username').fill(username)
   await page.locator('#password').fill(password)
   await page.locator('input[type=submit]').click()
+  await new LayoutModel(page).acceptOnlyNecessaryCookies()
   await expect(page.getByTestId('page-heading-etusivu')).toContainText('Hei Ludos, tervetuloa LUDOS-palveluun!')
 
   await page.getByTestId('user-menu-expand').click()

--- a/playwright/parallel_tests/localization.spec.ts
+++ b/playwright/parallel_tests/localization.spec.ts
@@ -27,7 +27,7 @@ async function assertKoodistoLanguageInPuhviKoetehtavaForm(page: Page, language:
 
 test.beforeEach(async ({ page }) => {
   await login(page, Role.YLLAPITAJA, 'sv')
-  await page.goto('/')
+  await new LayoutModel(page).acceptOnlyNecessaryCookies()
 })
 
 test('Business language is the default for UI, teaching language and koodisto language', async ({ page }) => {

--- a/playwright/parallel_tests/matomo.spec.ts
+++ b/playwright/parallel_tests/matomo.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/test'
+import { login, Role } from '../helpers'
+import { LayoutModel } from '../models/LayoutModel'
+
+async function checkForMatomoAnalyticsRequest(layout: LayoutModel, shouldExist = true) {
+  let matomoAnalyticsRequestDone = false
+
+  layout.page.on('request', (request) => {
+    if (request.url().includes(layout.partialMatomoAnalyticsUrl)) {
+      matomoAnalyticsRequestDone = true
+    }
+  })
+
+  await layout.acceptOnlyNecessaryCookies()
+  await layout.page.waitForTimeout(500)
+
+  if (shouldExist) {
+    expect(matomoAnalyticsRequestDone).toBe(true)
+  } else {
+    expect(matomoAnalyticsRequestDone).toBe(false)
+  }
+}
+
+async function waitForMatomoRequest(layout: LayoutModel) {
+  await layout.page.waitForRequest(
+    (request) => request.url().includes(layout.partialMatomoAnalyticsUrl) && request.method() === 'GET'
+  )
+}
+
+test.describe('Matomo', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page, Role.YLLAPITAJA)
+  })
+
+  test('should open on first page load and send requests after full cookie consent', async ({ page }) => {
+    const layout = new LayoutModel(page)
+    await page.goto('/')
+    void layout.acceptAllCookies()
+
+    await waitForMatomoRequest(layout)
+
+    await layout.headerSuko.click()
+    await waitForMatomoRequest(layout)
+
+    await page.reload()
+    await expect(layout.consentModal).toBeHidden()
+  })
+
+  test('should open on first page load and doesnt send requests after necessary cookie consent', async ({ page }) => {
+    const layout = new LayoutModel(page)
+    await page.goto('/')
+    await checkForMatomoAnalyticsRequest(layout, false)
+  })
+
+  test('settings should open from footer link', async ({ page }) => {
+    const layout = new LayoutModel(page)
+    await page.goto('/')
+
+    await checkForMatomoAnalyticsRequest(layout, false)
+
+    await layout.consentModalFooterButton.click()
+    await layout.consentModalSettingsButton.click()
+    await layout.consentModalTrackingCheckbox.check()
+    await layout.consentModalAcceptSelectedButton.click()
+    await waitForMatomoRequest(layout)
+  })
+})

--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,8 @@
 <html lang="fi">
   <head>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />    <link rel="icon" type="image/png" sizes="16x16" href="/assets/favicon-16x16.png">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/assets/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="96x96" href="/assets/favicon-96x96.png">
     <meta name="msapplication-TileImage" content="/assets/msapplication-TileImage">
@@ -11,6 +12,21 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Matomo -->
+    <script type="text/javascript">
+      var _paq = window._paq = window._paq || [];
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="//analytiikka.opintopolku.fi/matomo/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '33']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <!-- End Matomo Code -->
     <title>LUDOS</title>
   </head>
   <body>

--- a/web/index.html
+++ b/web/index.html
@@ -16,6 +16,7 @@
     <script type="text/javascript">
       var _paq = window._paq = window._paq || [];
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(['requireConsent'])
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/web/index.html
+++ b/web/index.html
@@ -22,7 +22,8 @@
       (function() {
         var u="//analytiikka.opintopolku.fi/matomo/";
         _paq.push(['setTrackerUrl', u+'matomo.php']);
-        _paq.push(['setSiteId', '33']);
+        var siteId = window.location && window.location.hostname ? (window.location.hostname.indexOf('.testiopintopolku.fi') !== -1 ? '31' : (window.location.hostname.indexOf('.opintopolku.fi') !== -1 ? '32' : '33')) : '33';
+        _paq.push(['setSiteId', siteId]);
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
       })();

--- a/web/package.json
+++ b/web/package.json
@@ -42,6 +42,7 @@
     "react-router-dom": "^6.21.3",
     "react-select": "^5.8.0",
     "tailwind-merge": "^2.2.1",
+    "typescript-cookie": "^1.0.6",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -1,4 +1,4 @@
-import { AriaAttributes, ButtonHTMLAttributes, DetailedHTMLProps } from 'react'
+import { AriaAttributes, ButtonHTMLAttributes, DetailedHTMLProps, ForwardedRef, forwardRef } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 type ButtonVariant = 'buttonPrimary' | 'buttonSecondary' | 'buttonGhost' | 'buttonDanger'
@@ -9,15 +9,17 @@ export interface ButtonProps
   customClass?: string
 }
 
-export const Button = ({ variant, children, customClass, ...props }: ButtonProps) => {
-  const isDisabled = props.disabled
+export const Button = forwardRef(
+  ({ variant, children, customClass, ...props }: ButtonProps, ref: ForwardedRef<HTMLButtonElement>) => {
+    const isDisabled = props.disabled
 
-  return (
-    <button className={twMerge(buttonClasses(variant), customClass, isDisabled && 'opacity-50')} {...props}>
-      {children}
-    </button>
-  )
-}
+    return (
+      <button ref={ref} className={twMerge(buttonClasses(variant), customClass, isDisabled && 'opacity-50')} {...props}>
+        {children}
+      </button>
+    )
+  }
+)
 
 export function buttonClasses(variant: ButtonVariant): string {
   return `${variant} rounded-sm px-4 py-2`

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -3,6 +3,7 @@ import { ExternalLink } from './ExternalLink'
 import { OPH_URL, TIETOSUOJA_SELOSTE_URL, virkailijanOpintopolkuUrl } from '../constants'
 import { useFeedbackUrl } from '../hooks/useFeedbackUrl'
 import { useLudosTranslation } from '../hooks/useLudosTranslation'
+import { ConsentModal } from './modal/ConsentModal'
 
 type FooterProps = {
   isPresentation?: boolean
@@ -16,6 +17,7 @@ export const Footer = ({ isPresentation }: FooterProps) => {
     <div
       className="row flex-wrap items-center text-xs mt-5 py-4 px-10 border-t-2 border-gray-separator"
       data-testid="footer">
+      <ConsentModal />
       <div className="w-full md:w-1/3">
         <a href={OPH_URL} target="_blank" rel="noopener noreferrer" title="Opetushallituksen nettisivut">
           <img className="h-12" src={logo} alt="Opetushallituksen logo" />

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -3,7 +3,9 @@ import { ExternalLink } from './ExternalLink'
 import { OPH_URL, TIETOSUOJA_SELOSTE_URL, virkailijanOpintopolkuUrl } from '../constants'
 import { useFeedbackUrl } from '../hooks/useFeedbackUrl'
 import { useLudosTranslation } from '../hooks/useLudosTranslation'
-import { ConsentModal } from './modal/ConsentModal'
+import { ConsentModal, ConsentModalHandles } from './modal/ConsentModal'
+import { Button } from './Button'
+import { useRef } from 'react'
 
 type FooterProps = {
   isPresentation?: boolean
@@ -12,12 +14,13 @@ type FooterProps = {
 export const Footer = ({ isPresentation }: FooterProps) => {
   const { t } = useLudosTranslation()
   const feedbackUrl = useFeedbackUrl()
+  const consentModalRef = useRef<ConsentModalHandles>(null)
 
   return (
     <div
       className="row flex-wrap items-center text-xs mt-5 py-4 px-10 border-t-2 border-gray-separator"
       data-testid="footer">
-      <ConsentModal />
+      <ConsentModal ref={consentModalRef} />
       <div className="w-full md:w-1/3">
         <a href={OPH_URL} target="_blank" rel="noopener noreferrer" title="Opetushallituksen nettisivut">
           <img className="h-12" src={logo} alt="Opetushallituksen logo" />
@@ -33,6 +36,13 @@ export const Footer = ({ isPresentation }: FooterProps) => {
           </ExternalLink>
           <ExternalLink url={virkailijanOpintopolkuUrl()}>{t('common.virkailijan-opintopolku')}</ExternalLink>
           <ExternalLink url={TIETOSUOJA_SELOSTE_URL}>{t('footer.tietosuoja')}</ExternalLink>
+          <Button
+            variant="buttonGhost"
+            className={'text-green-primary hover:underline'}
+            onClick={() => consentModalRef.current?.setIsOpen(true)}
+            data-testid="privacy-settings-button">
+            {t('consent.title')}
+          </Button>
         </div>
       )}
     </div>

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -5,6 +5,7 @@ import { Notification } from '../Notification'
 import { useMediaQuery } from '../../hooks/useMediaQuery'
 import { IS_MOBILE_QUERY } from '../../constants'
 import { twMerge } from 'tailwind-merge'
+import { useMatomoTracking } from '../../hooks/useMatomoTracking'
 
 interface TLayout {
   header?: ReactNode
@@ -13,6 +14,7 @@ interface TLayout {
 }
 
 export const Layout = ({ header = <Header />, footer = <Footer />, children }: TLayout) => {
+  useMatomoTracking()
   const isMobile = useMediaQuery({ query: IS_MOBILE_QUERY })
 
   return (

--- a/web/src/components/modal/ConsentModal.tsx
+++ b/web/src/components/modal/ConsentModal.tsx
@@ -1,0 +1,77 @@
+import React, { ReactNode, useState } from 'react'
+import styles from './modal.module.css'
+import { Button } from '../Button'
+import { useTranslation } from 'react-i18next'
+import { useModal } from './useModal'
+import { ModalHeader } from './ModalHeader'
+import { twMerge } from 'tailwind-merge'
+import { ExternalLink } from '../ExternalLink'
+import { TIETOSUOJA_SELOSTE_URL } from '../../constants'
+
+interface ConsentModalProps {}
+
+export const ConsentModal = ({}: ConsentModalProps) => {
+  const { t } = useTranslation()
+  const [isOpen, setIsOpen] = useState(true)
+  const [isSettingsOpen, setIsSettingsOpen] = useState(true)
+  const onClose = () => setIsOpen(false)
+  const { modalRef, dialogClasses, onCancel, onAnimEnd } = useModal({ open: isOpen, onClose })
+  const margin = 'm-6'
+
+  return (
+    <dialog
+      ref={modalRef}
+      className={dialogClasses}
+      /*onClose={onClose}*/
+      onCancel={(e) => {
+        e.preventDefault()
+      }}
+      onAnimationEnd={onAnimEnd}
+      aria-modal="true"
+      data-testid="consent-modal">
+      <div className={styles['modal__container']}>
+        <ModalHeader modalTitle={t('consent.modal.title')} />
+
+        <div className="flex-grow" />
+
+        <p className={margin}>{t('consent.modal.general-info')}</p>
+
+        <div className={margin}>
+          <ExternalLink url={TIETOSUOJA_SELOSTE_URL}>{t('footer.tietosuoja')}</ExternalLink>
+        </div>
+
+        {isSettingsOpen && (
+          <div className={twMerge(margin, 'border-t border-separate')}>
+            <h3 className="my-3">{t('consent.modal.settings-title')}</h3>
+            <input type="checkbox" disabled checked id="consent-mandatory-checkbox" name="mandatory" />
+            <label className="pl-2" htmlFor="consent-mandatory-checkbox">
+              {t('consent.modal.checkbox.mandatory')}
+            </label>
+            <br />
+            <input type="checkbox" id="consent-mandatory-tracking" name="tracking" />
+            <label className="pl-2" htmlFor="consent-mandatory-checkbox">
+              {t('consent.modal.checkbox.tracking')}
+            </label>
+          </div>
+        )}
+
+        <div className={twMerge('flex justify-end gap-5 min-w-[650px]', margin)}>
+          <Button
+            variant="buttonSecondary"
+            onClick={() => setIsSettingsOpen(!isSettingsOpen)}
+            data-testid="settings-button">
+            {isSettingsOpen ? t('consent.modal.hide-settings') : t('consent.modal.show-settings')}
+          </Button>
+          {isSettingsOpen && (
+            <Button variant="buttonSecondary" onClick={onClose} data-testid="accept-all-button">
+              {t('consent.modal.accept-selected')}
+            </Button>
+          )}
+          <Button variant="buttonPrimary" onClick={onClose} data-testid="accept-all-button">
+            {t('consent.modal.accept-all')}
+          </Button>
+        </div>
+      </div>
+    </dialog>
+  )
+}

--- a/web/src/components/modal/ConsentModal.tsx
+++ b/web/src/components/modal/ConsentModal.tsx
@@ -3,7 +3,6 @@ import styles from './modal.module.css'
 import { Button } from '../Button'
 import { useModal } from './useModal'
 import { ModalHeader } from './ModalHeader'
-import { twMerge } from 'tailwind-merge'
 import { ExternalLink } from '../ExternalLink'
 import { TIETOSUOJA_SELOSTE_URL } from '../../constants'
 import { getCookie, removeCookie, setCookie } from 'typescript-cookie'
@@ -83,7 +82,6 @@ const ConsentModalComponent: ForwardRefRenderFunction<ConsentModalHandles> = (_,
 
   const onClose = () => setIsOpen(false)
   const { modalRef, dialogClasses, onAnimEnd } = useModal({ open: isOpen, onClose })
-  const margin = 'm-6'
 
   const onAcceptAll = () => {
     rememberTrackingConsentGiven()
@@ -118,16 +116,14 @@ const ConsentModalComponent: ForwardRefRenderFunction<ConsentModalHandles> = (_,
       <div className={styles['modal__container']}>
         <ModalHeader modalTitle={t('consent.title')} />
 
-        <div className="flex-grow" />
+        <p className="m-6">{t('consent.modal.info')}</p>
 
-        <p className={margin}>{t('consent.modal.info')}</p>
-
-        <div className={margin}>
+        <div className="m-6">
           <ExternalLink url={TIETOSUOJA_SELOSTE_URL}>{t('footer.tietosuoja')}</ExternalLink>
         </div>
 
         {isSettingsOpen && (
-          <div className={twMerge(margin, 'border-t border-separate')}>
+          <div className="m-6 border-t border-separate">
             <h3 className="my-3">{t('consent.modal.settings-title')}</h3>
             <input type="checkbox" disabled checked id="consent-mandatory-checkbox" name="mandatory" />
             <label className="pl-2" htmlFor="consent-mandatory-checkbox">
@@ -140,6 +136,7 @@ const ConsentModalComponent: ForwardRefRenderFunction<ConsentModalHandles> = (_,
               checked={isTrackingConsentChecked}
               readOnly
               onClick={() => setIsTrackingConsentChecked(!isTrackingConsentChecked)}
+              data-testid="consent-tracking-checkbox"
             />
             <label className="pl-2" htmlFor="consent-tracking-checkbox">
               {t('consent.modal.checkbox.tracking')}
@@ -147,7 +144,7 @@ const ConsentModalComponent: ForwardRefRenderFunction<ConsentModalHandles> = (_,
           </div>
         )}
 
-        <div className={twMerge('flex justify-end gap-5 min-w-[650px]', margin)}>
+        <div className="flex justify-end m-6 gap-5 min-w-[650px]">
           <Button
             variant="buttonSecondary"
             onClick={() => setIsSettingsOpen(!isSettingsOpen)}

--- a/web/src/components/modal/ConsentModal.tsx
+++ b/web/src/components/modal/ConsentModal.tsx
@@ -102,6 +102,9 @@ const ConsentModalComponent: ForwardRefRenderFunction<ConsentModalHandles> = (_,
     resetAndSetIsOpen(false)
   }
 
+  if (!isOpen) {
+    return null
+  }
   return (
     <dialog
       ref={modalRef}
@@ -152,7 +155,7 @@ const ConsentModalComponent: ForwardRefRenderFunction<ConsentModalHandles> = (_,
             {isSettingsOpen ? t('consent.modal.hide-settings') : t('consent.modal.show-settings')}
           </Button>
           {isSettingsOpen && (
-            <Button variant="buttonSecondary" onClick={onAcceptSelected} data-testid="accept-all-button">
+            <Button variant="buttonSecondary" onClick={onAcceptSelected} data-testid="accept-selected-button">
               {t('consent.modal.accept-selected')}
             </Button>
           )}

--- a/web/src/components/modal/ConsentModal.tsx
+++ b/web/src/components/modal/ConsentModal.tsx
@@ -1,28 +1,111 @@
-import React, { ReactNode, useState } from 'react'
+import React, { forwardRef, ForwardRefRenderFunction, useEffect, useImperativeHandle, useState } from 'react'
 import styles from './modal.module.css'
 import { Button } from '../Button'
-import { useTranslation } from 'react-i18next'
 import { useModal } from './useModal'
 import { ModalHeader } from './ModalHeader'
 import { twMerge } from 'tailwind-merge'
 import { ExternalLink } from '../ExternalLink'
 import { TIETOSUOJA_SELOSTE_URL } from '../../constants'
+import { getCookie, removeCookie, setCookie } from 'typescript-cookie'
+import { useLudosTranslation } from '../../hooks/useLudosTranslation'
 
-interface ConsentModalProps {}
+const CONSENT_MODEL_SHOWN_COOKIE_NAME = 'ludosConsentModalShown'
+const MATOMO_CONSENT_COOKIE_NAME = 'mtm_consent'
 
-export const ConsentModal = ({}: ConsentModalProps) => {
-  const { t } = useTranslation()
-  const [isOpen, setIsOpen] = useState(true)
-  const [isSettingsOpen, setIsSettingsOpen] = useState(true)
+function isConsentModalAlreadyShown(): boolean {
+  return !!getCookie(CONSENT_MODEL_SHOWN_COOKIE_NAME)
+}
+
+function rememberConsentModalShown() {
+  removeCookie(CONSENT_MODEL_SHOWN_COOKIE_NAME)
+  setCookie(CONSENT_MODEL_SHOWN_COOKIE_NAME, Date.now(), { expires: 365, path: '/' })
+}
+
+function isMatomoConsentGivenRemembered() {
+  return !!getCookie(MATOMO_CONSENT_COOKIE_NAME)
+}
+
+function rememberMatomoConsentGiven() {
+  const window = globalThis as any
+  window._paq = window._paq || []
+  window._paq.push(['rememberConsentGiven'])
+  window._paq.push(['rememberConsentGiven']) // rememberConsentGiven needs to be called twice to remove mtm_consent_removed
+}
+
+function forgetMatomoConsentGiven() {
+  const window = globalThis as any
+  window._paq = window._paq || []
+  window._paq.push(['forgetConsentGiven'])
+}
+
+function isTrackingConsentRemembered(): boolean {
+  return isMatomoConsentGivenRemembered()
+}
+
+function rememberTrackingConsentGiven() {
+  rememberMatomoConsentGiven()
+}
+
+function forgetTrackingConsentGiven() {
+  forgetMatomoConsentGiven()
+}
+
+export interface ConsentModalHandles {
+  setIsOpen: (isOpen: boolean) => void
+}
+
+const ConsentModalComponent: ForwardRefRenderFunction<ConsentModalHandles> = (_, ref) => {
+  const { t } = useLudosTranslation()
+  const [isOpen, setIsOpen] = useState(!isConsentModalAlreadyShown())
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false)
+  const [isTrackingConsentChecked, setIsTrackingConsentChecked] = useState(isTrackingConsentRemembered())
+  const autofocusRef = React.useRef<HTMLButtonElement>(null)
+
+  const resetModal = () => {
+    setIsSettingsOpen(false)
+    setIsTrackingConsentChecked(isTrackingConsentRemembered())
+  }
+
+  const resetAndSetIsOpen = (isOpen: boolean) => {
+    resetModal()
+    setIsOpen(isOpen)
+  }
+
+  useImperativeHandle(ref, () => ({
+    setIsOpen: resetAndSetIsOpen
+  }))
+
+  useEffect(() => {
+    if (isOpen) {
+      autofocusRef.current?.focus()
+    }
+  }, [isOpen])
+
   const onClose = () => setIsOpen(false)
-  const { modalRef, dialogClasses, onCancel, onAnimEnd } = useModal({ open: isOpen, onClose })
+  const { modalRef, dialogClasses, onAnimEnd } = useModal({ open: isOpen, onClose })
   const margin = 'm-6'
+
+  const onAcceptAll = () => {
+    rememberTrackingConsentGiven()
+
+    rememberConsentModalShown()
+    resetAndSetIsOpen(false)
+  }
+  const onAcceptSelected = () => {
+    if (isTrackingConsentChecked) {
+      rememberTrackingConsentGiven()
+    } else {
+      forgetTrackingConsentGiven()
+    }
+
+    rememberConsentModalShown()
+    resetAndSetIsOpen(false)
+  }
 
   return (
     <dialog
       ref={modalRef}
       className={dialogClasses}
-      /*onClose={onClose}*/
       onCancel={(e) => {
         e.preventDefault()
       }}
@@ -30,11 +113,11 @@ export const ConsentModal = ({}: ConsentModalProps) => {
       aria-modal="true"
       data-testid="consent-modal">
       <div className={styles['modal__container']}>
-        <ModalHeader modalTitle={t('consent.modal.title')} />
+        <ModalHeader modalTitle={t('consent.title')} />
 
         <div className="flex-grow" />
 
-        <p className={margin}>{t('consent.modal.general-info')}</p>
+        <p className={margin}>{t('consent.modal.info')}</p>
 
         <div className={margin}>
           <ExternalLink url={TIETOSUOJA_SELOSTE_URL}>{t('footer.tietosuoja')}</ExternalLink>
@@ -48,8 +131,14 @@ export const ConsentModal = ({}: ConsentModalProps) => {
               {t('consent.modal.checkbox.mandatory')}
             </label>
             <br />
-            <input type="checkbox" id="consent-mandatory-tracking" name="tracking" />
-            <label className="pl-2" htmlFor="consent-mandatory-checkbox">
+            <input
+              type="checkbox"
+              id="consent-tracking-checkbox"
+              checked={isTrackingConsentChecked}
+              readOnly
+              onClick={() => setIsTrackingConsentChecked(!isTrackingConsentChecked)}
+            />
+            <label className="pl-2" htmlFor="consent-tracking-checkbox">
               {t('consent.modal.checkbox.tracking')}
             </label>
           </div>
@@ -63,11 +152,11 @@ export const ConsentModal = ({}: ConsentModalProps) => {
             {isSettingsOpen ? t('consent.modal.hide-settings') : t('consent.modal.show-settings')}
           </Button>
           {isSettingsOpen && (
-            <Button variant="buttonSecondary" onClick={onClose} data-testid="accept-all-button">
+            <Button variant="buttonSecondary" onClick={onAcceptSelected} data-testid="accept-all-button">
               {t('consent.modal.accept-selected')}
             </Button>
           )}
-          <Button variant="buttonPrimary" onClick={onClose} data-testid="accept-all-button">
+          <Button variant="buttonPrimary" onClick={onAcceptAll} data-testid="accept-all-button" ref={autofocusRef}>
             {t('consent.modal.accept-all')}
           </Button>
         </div>
@@ -75,3 +164,5 @@ export const ConsentModal = ({}: ConsentModalProps) => {
     </dialog>
   )
 }
+
+export const ConsentModal = forwardRef(ConsentModalComponent)

--- a/web/src/components/modal/ModalHeader.tsx
+++ b/web/src/components/modal/ModalHeader.tsx
@@ -1,12 +1,14 @@
 import { Icon } from '../Icon'
 
-export const ModalHeader = ({ modalTitle, onClick }: { modalTitle: string; onClick: () => void }) => (
+export const ModalHeader = ({ modalTitle, onClick }: { modalTitle: string; onClick?: () => void }) => (
   <div className="row justify-between bg-green-primary p-2">
     <h2 className="text-base text-white" id="modal-title">
       {modalTitle}
     </h2>
-    <button className="modal__close-button text-right" onClick={onClick} aria-label="modal-close">
-      <Icon name="sulje" color="text-white" />
-    </button>
+    {onClick && (
+      <button className="modal__close-button text-right" onClick={onClick} aria-label="modal-close">
+        <Icon name="sulje" color="text-white" />
+      </button>
+    )}
   </div>
 )

--- a/web/src/hooks/useMatomoTracking.ts
+++ b/web/src/hooks/useMatomoTracking.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+
+export const useMatomoTracking = () => {
+  const location = useLocation()
+
+  useEffect(() => {
+    const window = globalThis as any
+    window._paq = window._paq || []
+
+    // Track page view
+    window._paq.push(['setCustomUrl', window.location.href])
+    window._paq.push(['setDocumentTitle', document.title])
+    window._paq.push(['trackPageView'])
+  }, [location])
+}

--- a/web/src/hooks/useMatomoTracking.ts
+++ b/web/src/hooks/useMatomoTracking.ts
@@ -9,8 +9,8 @@ export const useMatomoTracking = () => {
     window._paq = window._paq || []
 
     // Track page view
-    window._paq.push(['setCustomUrl', window.location.href])
+    window._paq.push(['setCustomUrl', `${window.location.origin}${location.pathname}`])
     window._paq.push(['setDocumentTitle', document.title])
     window._paq.push(['trackPageView'])
-  }, [location])
+  }, [location.pathname])
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4440,6 +4440,11 @@ typed-array-length@^1.0.4:
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
 
+typescript-cookie@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/typescript-cookie/-/typescript-cookie-1.0.6.tgz#009b0665706b2cc856f796e76cf408a16ef011c5"
+  integrity sha512-s+BZr7/9BUG6Kg7jGGcOY/4XJcP+iZRFdF3q4FPTfRSP83ivLWF94OcH8PrzGmnS8Ab9qP7ENu/ikLwNFsIafA==
+
 typescript@^5.3.3:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"


### PR DESCRIPTION
TODO
- [x] Playwright-testit consent-dialogille
   - [x] että modaali tulee esiin ekalla sivulatauksella ja sen saa piiloon hyväksymällä kaikki keksit, ja että navigoinnista seuraa sitten matomo-kutsuja
   - [x] että modaali tulee esiin ekalla sivulatauksella ja sen saa piiloon hyväksymällä vain pakolliset keksit, ja että navigoinnista EI seuraa matomo-kutsuja.
   - [x] että modaali tulee esiin ekalla sivulatauksella ja sen saa piiloon valitsemalla asetuksista tracking-keksit ja tallentamalla valitut, ja että navigoinnisdta seuraa sitten matomo-kutsuja.
   - [x] että modaalin saa esiin footerista, ja asetuksia voi muuttaa, ja se vaikuttaa siihen, tehdäänkö matomo-kutsuja

Testi kannattanee kirjoitta localization.spec.ts -tyyliin ilman että käyttää auth.setup.ts:n storageState-tiedostoja, niin saa itse testata vielä erikseen käyttäjän ensimmäisen consent-modal-pompsahduksen:

```
test.beforeEach(async ({ page }) => {
  await login(page, Role.YLLAPITAJA)
})
```
