### PR TITLE
OPHLUDOS-180: Suosikkitoiminnnon kaytettavyys

### DIFF
--- a/playwright/models/AssignmentFavoriteModel.ts
+++ b/playwright/models/AssignmentFavoriteModel.ts
@@ -65,9 +65,14 @@ export class AssignmentFavoriteModel extends BaseModel {
       .toBe(expectedCount)
   }
 
+  private async removeFavorite(assignmentCard: any, favoriteCountBefore: number) {
+    await assignmentCard.getByTestId('suosikki').click()
+    await assertSuccessNotification(this.page, 'assignment.notification.suosikki-poistettu')
+    await expect(assignmentCard).toBeHidden()
+  }
+
   async assertFavoritesPage(assignment: any, favoriteCountBefore: number) {
     await this.headerFavorites.click()
-    await this.goToExamTab()
 
     const assignmentCard = this.page.getByTestId(`assignment-list-item-${assignment.id}`)
 
@@ -75,11 +80,7 @@ export class AssignmentFavoriteModel extends BaseModel {
     await assignmentCard.getByTestId('card-title').click()
     await expect(this.page.getByTestId('assignment-header')).toHaveText(assignment.nameFi)
     await this.page.goBack()
-    await assignmentCard.getByTestId('suosikki').click()
-    await this.checkBoxFavoriteRoot.uncheck()
-    await this.addToFavoritesBtn.click()
-    await assertSuccessNotification(this.page, 'assignment.notification.suosikki-muokattu')
-    await expect(assignmentCard).toBeHidden()
+    await this.removeFavorite(assignmentCard, favoriteCountBefore)
 
     await this.assertFavoriteCountIsEventually(favoriteCountBefore)
   }
@@ -131,8 +132,7 @@ export class AssignmentFavoriteModel extends BaseModel {
     await expect(favoriteButtonLocator.locator('span')).toHaveText('favorite.lisaa-suosikiksi')
     await favoriteButtonLocator.click()
     await this.addToFavoritesBtn.click()
-    await assertSuccessNotification(this.page, 'assignment.notification.suosikki-muokattu')
-    await expect(favoriteButtonLocator.locator('span')).toHaveText('favorite.muokkaa-suosikkeja')
+    await assertSuccessNotification(this.page, 'assignment.notification.suosikki-lisatty')
     await this.assertFavoriteCountIsEventually(favoriteCountBefore + 1)
 
     await this.assertFavoritesPage(assignment, favoriteCountBefore)

--- a/playwright/parallel_tests/assignment/assignmentFavorites.spec.ts
+++ b/playwright/parallel_tests/assignment/assignmentFavorites.spec.ts
@@ -34,7 +34,6 @@ Object.values(Exam).forEach(async (exam) => {
       const [assignment, _] = await favorite.prepAssignmentGoToAssignmentList(baseURL!)
 
       await favorite.headerFavorites.click()
-      await favorite.goToExamTab()
 
       const folderId = await favorite.createFolder(newFolderName)
 
@@ -46,7 +45,6 @@ Object.values(Exam).forEach(async (exam) => {
       await favorite.addToFavoritesBtn.click()
 
       await favorite.headerFavorites.click()
-      await favorite.goToExamTab()
 
       await expect(page.getByRole('link', { name: newFolderName }).first()).toBeVisible()
       await favorite.goToFolder(folderId)
@@ -65,24 +63,24 @@ Object.values(Exam).forEach(async (exam) => {
 
       const assignmentCard = page.getByTestId(`assignment-list-item-${assignment.id}`)
       const assignmentCardFavoriteBtn = assignmentCard.getByTestId('suosikki')
+      const assignmentCardFolderBtn = assignmentCard.getByTestId('folder')
 
       await favorite.layout.navHeaderGoToPageByExam(exam)
       await assignmentCardFavoriteBtn.click()
       await favorite.addToFavoritesBtn.click()
 
       await favorite.headerFavorites.click()
-      await favorite.goToExamTab()
 
       const folderId = await favorite.createFolder('folder 1')
       const folderId2 = await favorite.createFolder('folder 2')
 
-      await assignmentCardFavoriteBtn.click()
+      await assignmentCardFolderBtn.click()
       await favorite.doFolderSelectionInToggleFavoriteModal([folderId], [0])
 
       await page.getByTestId(`folder-${folderId}-card`).getByTestId('link').click()
       await expect(assignmentCard).toBeVisible()
 
-      await assignmentCardFavoriteBtn.click()
+      await assignmentCardFolderBtn.click()
       await favorite.doFolderSelectionInToggleFavoriteModal([folderId2], [folderId])
 
       await expect(assignmentCard).toBeHidden()

--- a/web/src/components/Breadcrumbs.tsx
+++ b/web/src/components/Breadcrumbs.tsx
@@ -7,13 +7,13 @@ import { contentListPath, examPath, favoritesPagePath, frontpagePath } from './L
 import { useParams } from 'react-router-dom'
 
 const BreadcrumbItem = ({ last, name, index, path }: { last: boolean; name: string; path: string; index: number }) => (
-  <div className="text-xs">
+  <div className="text-sm">
     {last ? (
       <p>/ {name}</p>
     ) : (
       <>
         {index > 0 ? '/ ' : ''}
-        <InternalLink className="px-1" to={path}>
+        <InternalLink className="pr-1" to={path}>
           {name}
         </InternalLink>
       </>
@@ -47,7 +47,7 @@ export const FavoriteFolderBreadcrumbs = ({ exam, segments }: BreadcrumbsProps) 
         <BreadcrumbItem
           last={index + 1 === pathsAndNames.length}
           name={name}
-          path={id === exam.toLowerCase() ? `${favoritesPagePath()}/${id}` : `${favoritesPagePath(exam)}/${id}`}
+          path={id === exam.toLowerCase() ? `${favoritesPagePath(exam)}` : `${favoritesPagePath(exam)}/${id}`}
           index={index}
           key={index}
         />

--- a/web/src/components/LudosRoutes.tsx
+++ b/web/src/components/LudosRoutes.tsx
@@ -41,7 +41,7 @@ export const contentListPath = (exam: Exam, contentType: ContentType, search?: s
 export const editingFormPath = ({ exam, contentType, id }: ContentBaseOut) =>
   `${examPath(exam)}/${ContentTypePluralFi[contentType]}/${muokkausKey}/${id}`
 
-export const favoritesPagePath = (exam?: Exam) => `/${suosikitKey}${exam ? `/${exam.toLowerCase()}` : ''}`
+export const favoritesPagePath = (exam: Exam = Exam.SUKO) => `/${suosikitKey}/${exam.toLowerCase()}`
 
 export const pageNotFoundPath = '/sivua-ei-loydy'
 

--- a/web/src/components/content/AssignmentContent.tsx
+++ b/web/src/components/content/AssignmentContent.tsx
@@ -2,6 +2,7 @@ import {
   AssignmentOut,
   ContentType,
   ContentTypeSingularEn,
+  FavoriteAction,
   FavoriteIdsDtoOut,
   isLdAssignment,
   isPuhviAssignment,
@@ -14,6 +15,7 @@ import { useState } from 'react'
 import { useSetFavoriteFolders } from '../../hooks/useSetFavoriteFolders'
 import { SetFavoriteFoldersModal } from '../modal/favoriteModal/SetFavoriteFoldersModal'
 import { useFetch } from '../../hooks/useFetch'
+import { FavoriteToggleModalFormType } from '../modal/favoriteModal/favoriteToggleModalFormSchema'
 import { useLudosTranslation } from '../../hooks/useLudosTranslation'
 
 type AssignmentContentProps = {
@@ -32,9 +34,14 @@ export const AssignmentContent = ({ assignment, teachingLanguage, isPresentation
     `${ContentTypeSingularEn.ASSIGNMENT}/favorites/${assignment.exam.toLocaleUpperCase()}/${assignment.id}`
   )
 
-  const { setFavoriteFolder } = useSetFavoriteFolders(refetchFavoriteData)
+  const { setFavoriteFolders, unFavorite } = useSetFavoriteFolders(refetchFavoriteData)
 
   const isFavorite = (favoriteIds && favoriteIds?.folderIdsByAssignmentId[assignment.id] !== undefined) || false
+
+  const onSetFavoriteFoldersAction = async (data: FavoriteToggleModalFormType) => {
+    await setFavoriteFolders({ data, favoriteAction: isFavorite ? FavoriteAction.EDIT : FavoriteAction.ADD })
+    setIsFavoriteModalOpen(false)
+  }
 
   return (
     <>
@@ -53,10 +60,6 @@ export const AssignmentContent = ({ assignment, teachingLanguage, isPresentation
                     {getKoodiLabel(assignment.assignmentTypeKoodiArvo, 'tehtavatyyppisuko')}
                   </span>
                 </li>
-                {/*<li}
-                {/*  <span className="pr-1 font-semibold">{t('assignment.tavoitetaso')}:</span>*/}
-                {/*  <span data-testid="suko-tavoitetaso">{getKoodiLabel(assignment.tavoitetasoKoodiArvo, 'taitotaso')}</span>*/}
-                {/*</li>*/}
                 <li>
                   <span className="pr-1 font-semibold">{t('assignment.aihe')}:</span>
                   <span data-testid="suko-aihe">
@@ -99,7 +102,9 @@ export const AssignmentContent = ({ assignment, teachingLanguage, isPresentation
 
           <ContentActionRow
             isFavorite={isFavorite}
-            onFavoriteClick={() => setIsFavoriteModalOpen(true)}
+            onFavoriteClick={() => {
+              isFavorite ? unFavorite(assignment) : setIsFavoriteModalOpen(true)
+            }}
             pdfData={{
               baseOut: assignment,
               language: teachingLanguage,
@@ -131,10 +136,7 @@ export const AssignmentContent = ({ assignment, teachingLanguage, isPresentation
             (teachingLanguage === Language.FI ? assignment.nameFi : assignment.nameSv) || t('form.nimeton')
           }
           onClose={() => setIsFavoriteModalOpen(false)}
-          onSetFavoriteFoldersAction={async (favoriteCards) => {
-            await setFavoriteFolder(favoriteCards)
-            setIsFavoriteModalOpen(false)
-          }}
+          onSetFavoriteFoldersAction={onSetFavoriteFoldersAction}
         />
       )}
     </>

--- a/web/src/components/content/ContentCommon.tsx
+++ b/web/src/components/content/ContentCommon.tsx
@@ -120,7 +120,7 @@ export function ContentActionRow({ isFavorite, disabled, onFavoriteClick, pdfDat
       {pdfData && (
         <Suspense
           fallback={
-            <Button variant="buttonGhost" customClass="p-0 flex items-center pr-3" disabled>
+            <Button variant="buttonGhost" customClass="p-0 flex items-center" disabled>
               <Icon name="pdf" color="text-green-primary" />
               <span className="ml-1 text-xs text-green-primary">{t('assignment.lataapdf')}</span>
             </Button>
@@ -133,7 +133,7 @@ export function ContentActionRow({ isFavorite, disabled, onFavoriteClick, pdfDat
           contentAction={{
             actionName: 'suosikki',
             iconName: 'suosikki',
-            text: isFavorite ? t('favorite.muokkaa-suosikkeja') : t('favorite.lisaa-suosikiksi')
+            text: isFavorite ? t('favorite.poista-suosikeista') : t('favorite.lisaa-suosikiksi')
           }}
           onClickHandler={onFavoriteClick}
           isActive={isFavorite}

--- a/web/src/components/content/assignmentFavorite/AssignmentFavoriteTopBar.tsx
+++ b/web/src/components/content/assignmentFavorite/AssignmentFavoriteTopBar.tsx
@@ -44,22 +44,19 @@ export const AssignmentFavoriteTopBar = ({
 
   return (
     <>
-      <div className="row flex-wrap justify-between pb-3 pt-6">
-        {segments.length > 1 && currentFolder.id ? (
-          <div className="row items-center gap-2 pb-4 md:pb-0">
-            <FavoriteFolderBreadcrumbs exam={exam} segments={segments} />
-            <AssignmentFavoriteFolderDropdownMenu
-              exam={exam}
-              favoriteCardFolders={assignmentFavorites}
-              currentFavoriteCardFolder={currentFolder}
-              refresh={favoriteCardFoldersRefetch}
-            />
-          </div>
-        ) : (
-          <div />
-        )}
-        <div className="row gap-6 items-center">
-          {exam !== Exam.SUKO && <TeachingLanguageSelectWithLabel text={t('filter.koetehtavat-kieli')} />}
+      <div className="row flex-wrap justify-between pb-1 pt-4">
+        <div>
+          {segments.length > 1 && currentFolder.id && (
+            <div className="row items-center gap-2 pb-4 md:pb-0">
+              <FavoriteFolderBreadcrumbs exam={exam} segments={segments} />
+              <AssignmentFavoriteFolderDropdownMenu
+                exam={exam}
+                favoriteCardFolders={assignmentFavorites}
+                currentFavoriteCardFolder={currentFolder}
+                refresh={favoriteCardFoldersRefetch}
+              />
+            </div>
+          )}
           <Button
             variant="buttonPrimary"
             onClick={() => setOpenAddNewFolderModal(true)}
@@ -69,6 +66,10 @@ export const AssignmentFavoriteTopBar = ({
               <span className="pl-1">{t('favorite.lisaa-kansio')}</span>
             </span>
           </Button>
+        </div>
+
+        <div className="row gap-6 items-center">
+          {exam !== Exam.SUKO && <TeachingLanguageSelectWithLabel text={t('filter.koetehtavat-kieli')} />}
         </div>
       </div>
       {openAddNewFolderModal && (

--- a/web/src/components/content/list/assignment/AssignmentCardContentActions.tsx
+++ b/web/src/components/content/list/assignment/AssignmentCardContentActions.tsx
@@ -21,7 +21,7 @@ function AssignmentCardContentActionButton({
   onClickHandler,
   isDisabled
 }: AssignmentCardContentActionButtonProps) {
-  const className = 'flex items-center pr-3'
+  const className = 'flex items-center'
   const children = (
     <>
       <Icon name={iconName} color="text-green-primary" filled={isIconFilled} />
@@ -44,7 +44,7 @@ function AssignmentCardContentActionButton({
     return (
       <Button
         variant="buttonGhost"
-        customClass="p-0 flex items-center pr-3"
+        customClass="p-0 flex items-center"
         onClick={onClickHandler}
         disabled={isDisabled}
         data-testid={actionName}>
@@ -56,25 +56,34 @@ function AssignmentCardContentActionButton({
 
 const PdfDownloadButton = lazy(() => import('../../pdf/PdfDownloadButton'))
 
+type FavoriteActionProps = {
+  isFavorite: boolean
+  onClick: () => void
+  isDisabled: boolean
+}
+
+type MoveFolderActionProps = {
+  onClick: () => void
+  hasFolders: boolean
+}
+
 type AssignmentCardContentActionsProps = {
   assignment: AssignmentCardOut
-  isFavorite?: boolean
-  onFavoriteClick?: () => void
-  isFavoriteButtonDisabled: boolean
   language: Language
+  favoriteAction: FavoriteActionProps
+  moveFolderAction?: MoveFolderActionProps
 }
 
 export const AssignmentCardContentActions = ({
   assignment,
-  isFavorite,
-  onFavoriteClick,
-  isFavoriteButtonDisabled,
-  language
+  language,
+  favoriteAction,
+  moveFolderAction
 }: AssignmentCardContentActionsProps) => {
   const { t } = useLudosTranslation()
 
   return (
-    <div className="flex w-full flex-wrap items-center justify-evenly md:w-4/12 md:justify-end">
+    <div className="flex w-full flex-wrap items-center justify-evenly gap-3 pr-2 md:w-5/12 md:justify-end">
       <AssignmentCardContentActionButton
         assignment={assignment}
         contentAction={{
@@ -99,13 +108,26 @@ export const AssignmentCardContentActions = ({
         contentAction={{
           actionName: 'suosikki',
           iconName: 'suosikki',
-          text: isFavorite ? t('favorite.muokkaa-suosikkeja') : t('favorite.lisaa-suosikiksi')
+          text: favoriteAction.isFavorite ? t('favorite.poista-suosikeista') : t('favorite.lisaa-suosikiksi')
         }}
-        onClickHandler={onFavoriteClick}
-        isIconFilled={isFavorite}
-        isDisabled={isFavoriteButtonDisabled}
+        onClickHandler={favoriteAction.onClick}
+        isIconFilled={favoriteAction.isFavorite}
+        isDisabled={favoriteAction.isDisabled}
         key="suosikki"
       />
+      {moveFolderAction && (
+        <AssignmentCardContentActionButton
+          assignment={assignment}
+          contentAction={{
+            actionName: 'folder',
+            iconName: 'kansio',
+            text: t('favorite.siirra-kansioon')
+          }}
+          onClickHandler={moveFolderAction.onClick}
+          isDisabled={!moveFolderAction.hasFolders}
+          key="folder"
+        />
+      )}
     </div>
   )
 }

--- a/web/src/components/content/pdf/PdfDownloadButton.tsx
+++ b/web/src/components/content/pdf/PdfDownloadButton.tsx
@@ -44,7 +44,7 @@ export default function PdfDownloadButton({ exam, contentId, language }: PdfDown
     <>
       <Button
         variant="buttonGhost"
-        customClass="p-0 flex items-center pr-3"
+        customClass="p-0 flex items-center"
         onClick={handleDownloadClick}
         disabled={!!assignmentShouldBeGenerated}
         data-testid={`pdf-download-button-${language}`}>

--- a/web/src/components/header/HeaderFavorites.tsx
+++ b/web/src/components/header/HeaderFavorites.tsx
@@ -4,7 +4,11 @@ import { Icon } from '../Icon'
 import { favoritesPagePath } from '../LudosRoutes'
 import { InternalLink } from '../InternalLink'
 import { twMerge } from 'tailwind-merge'
+import { useLocation } from 'react-router-dom'
 import { useLudosTranslation } from '../../hooks/useLudosTranslation'
+import { Exam } from '../../types'
+
+const toLower = (str: string) => str.toLowerCase()
 
 type HeaderFavoritesProps = {
   userFavoriteAssignmentCount: number
@@ -13,6 +17,11 @@ type HeaderFavoritesProps = {
 
 export const HeaderFavorites = ({ userFavoriteAssignmentCount, isMobile }: HeaderFavoritesProps) => {
   const { t } = useLudosTranslation()
+  const location = useLocation()
+
+  const pathSegments = location.pathname.split('/')
+  const examInPath = pathSegments.find((p) => Object.values(Exam).map(toLower).includes(p))
+  const exam: Exam = examInPath ? (examInPath.toUpperCase() as Exam) : Exam.SUKO
 
   return (
     <InternalLink
@@ -20,7 +29,7 @@ export const HeaderFavorites = ({ userFavoriteAssignmentCount, isMobile }: Heade
         buttonClasses('buttonGhost'),
         'flex justify-center gap-1 border-l border-green-primary pt-1 pb-0 pr-2'
       )}
-      to={favoritesPagePath()}
+      to={favoritesPagePath(exam)}
       data-testid="header-favorites">
       {isMobile ? null : <span className="text-green-primary">{t('favorite.suosikit')}</span>}
       <div className="relative">

--- a/web/src/hooks/useLudosTranslation.ts
+++ b/web/src/hooks/useLudosTranslation.ts
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { Icons } from '../components/Icon'
-import { AddToFavoriteOptions, ContentOrder, ContentType, Exam, Language, PublishState } from '../types'
+import { AddToFavoriteOptions, ContentOrder, ContentType, Exam, FavoriteAction, Language, PublishState } from '../types'
 import { KoodiDtoOut } from './useKoodisto'
 import { TFunction } from 'i18next'
 
@@ -176,6 +176,11 @@ export const useLudosTranslation = () => {
       OPETTAJA: t('header.opettaja'),
       LAATIJA: t('header.laatija'),
       UNAUTHORIZED: t('header.luvaton')
+    },
+    favoriteActionNotificationTexts: {
+      [FavoriteAction.ADD]: t('assignment.notification.suosikki-lisatty'),
+      [FavoriteAction.REMOVE]: t('assignment.notification.suosikki-poistettu'),
+      [FavoriteAction.EDIT]: t('assignment.notification.suosikki-muokattu')
     }
   }
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -39,6 +39,13 @@ export const Exam = {
 } as const
 export type Exam = (typeof Exam)[keyof typeof Exam]
 
+export const FavoriteAction = {
+  ADD: 'ADD',
+  REMOVE: 'REMOVE',
+  EDIT: 'EDIT'
+} as const
+export type FavoriteAction = (typeof FavoriteAction)[keyof typeof FavoriteAction]
+
 export interface ContentBase {
   nameFi: string
   nameSv: string


### PR DESCRIPTION
- [x] lisää kansio -nappi vasempaan reunaan
- [x] kun siirrytään Puhvi/LD-kontekstista suosikkeihin, kannattaisi esivalita oikea välilehti. 
- [x] Tehtäväkortteihin tulee joko "Lisää suosikiksi" tai "Poista suosikeista". Poistetaan "muokkaa suosikkeja"-toiminto, johon käyttäjät eivät ole suosikkitoiminnoissa tottuneet. Nämä toiminnot esitetään tehtävälistauksessa tai yksittäisen tehtävän sivulla. Lisäksi suosikit-näkymässä on myös "Siirrä kansioon"-toiminto.
- [x] Tehtävien "muokkaukset" tehdään jatkossa vain suosikkinäkymässä. Voi poistaa tai vaihtaa tehtävän toiseen kansioon ovat riittävät muokkaukset yksittäiselle tehtävälle.
- [x] tarkista notifikaatiot
- [x] lisätä testi uudelle suosikin poisto napille
- [x] Lokalisaatio tekstit